### PR TITLE
Add eval design guidance to README and create-eval template

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,55 @@ skilljack-evals run evals/my-skill/tasks.yaml --verbose
 
 This workflow ensures your skill is discoverable from the right prompts, doesn't activate when it shouldn't, and produces the output quality you expect.
 
+## Writing Effective Evals
+
+Practical tips for writing eval tasks that surface real issues and drive meaningful skill improvements. Adapted from the [agentskills.io evaluation guide](https://agentskills.io/skill-creation/evaluating-skills).
+
+### Test Case Design
+
+- **Start small** — 2-3 tasks are enough for a first run. Expand after you see initial results.
+- **Vary your prompts** — use different phrasings, detail levels, and formality. `"hey can you format this CSV"` tests something different than `"Parse the CSV at data/sales.csv and output a summary table"`.
+- **Cover edge cases** — include at least one boundary condition: malformed input, an ambiguous request, or a prompt that's close but shouldn't trigger the skill.
+- **Use realistic context** — include file paths, column names, and specifics rather than generic placeholders like "process this data".
+
+### Golden Checklist Writing
+
+Good checklist items are specific, observable, and verifiable:
+
+```yaml
+golden_checklist:
+  - "The output file is valid JSON"              # programmatically verifiable
+  - "The chart has labeled axes"                  # specific and observable
+  - "The report includes at least 3 recommendations"  # countable
+```
+
+Weak checklist items hurt scoring accuracy:
+
+```yaml
+golden_checklist:
+  - "The output is good"                          # too vague to evaluate
+  - "Uses exactly the phrase 'Total Revenue: $X'" # too brittle — correct output with different wording fails
+```
+
+**Guidelines:**
+- Prefer items that can be checked objectively
+- Remove items that always pass regardless of skill quality — they inflate scores without adding signal
+- Review the checklist after your first run and fix items that are too easy, too hard, or unverifiable
+
+### Skill Improvement Strategies
+
+- **Generalize from feedback** — address underlying issues broadly rather than adding narrow patches for specific test cases
+- **Keep the skill lean** — fewer, better instructions often outperform exhaustive rules. If pass rates plateau despite adding more rules, try removing some
+- **Explain the why** — `"Validate JSON before writing because partial writes corrupt state"` works better than `"ALWAYS validate JSON, NEVER skip validation"`
+- **Bundle repeated work** — if every eval run independently writes a similar helper script, add it to the skill's `scripts/` directory
+
+### Scoring Principles
+
+- **Require concrete evidence for a PASS** — don't give the benefit of the doubt
+- **Review the checklist, not just results** — notice when items always pass (too easy), always fail (too hard), or can't be objectively verified
+
+For detailed guidance, see the full [evaluation documentation on agentskills.io](https://agentskills.io/skill-creation/evaluating-skills).
+
 ## Multi-Runner Support
 
 Three runners are available, selected via the `--runner` CLI flag:

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as yaml from 'js-yaml';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { createEvalTemplate, validateEvalFile } from '../parser.js';
+
+describe('createEvalTemplate', () => {
+  const tmpFiles: string[] = [];
+
+  afterEach(async () => {
+    for (const f of tmpFiles) {
+      await fs.rm(f, { force: true }).catch(() => {});
+    }
+    tmpFiles.length = 0;
+  });
+
+  it('generates correct number of positive + 1 false-positive task', () => {
+    const template = createEvalTemplate('my-skill', 5);
+    const doc = yaml.load(template) as { tasks: { id: string; deterministic?: { expect_skill_activation: boolean } }[] };
+
+    const positive = doc.tasks.filter(t => t.deterministic?.expect_skill_activation !== false);
+    const fp = doc.tasks.filter(t => t.deterministic?.expect_skill_activation === false);
+
+    expect(positive).toHaveLength(4);
+    expect(fp).toHaveLength(1);
+    expect(doc.tasks).toHaveLength(5);
+  });
+
+  it('ensures at least 1 positive task when numTasks is 1', () => {
+    const template = createEvalTemplate('my-skill', 1);
+    const doc = yaml.load(template) as { tasks: { id: string; deterministic?: { expect_skill_activation: boolean } }[] };
+
+    const positive = doc.tasks.filter(t => t.deterministic?.expect_skill_activation !== false);
+    const fp = doc.tasks.filter(t => t.deterministic?.expect_skill_activation === false);
+
+    expect(positive).toHaveLength(1);
+    expect(fp).toHaveLength(1);
+    // Total is 2 because we always guarantee at least 1 positive + 1 FP
+    expect(doc.tasks).toHaveLength(2);
+  });
+
+  it('produces valid YAML that round-trips', () => {
+    const template = createEvalTemplate('test-skill', 3);
+    const doc = yaml.load(template) as Record<string, unknown>;
+
+    expect(doc).toBeDefined();
+    expect(doc.skill).toBe('test-skill');
+    expect(doc.version).toBe('1.0');
+    expect(Array.isArray(doc.tasks)).toBe(true);
+  });
+
+  it('has unique task IDs', () => {
+    const template = createEvalTemplate('my-skill', 10);
+    const doc = yaml.load(template) as { tasks: { id: string }[] };
+
+    const ids = doc.tasks.map(t => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('false-positive task has expected_skill_load: none', () => {
+    const template = createEvalTemplate('my-skill', 3);
+    const doc = yaml.load(template) as { tasks: { id: string; expected_skill_load?: string; deterministic?: { expect_skill_activation: boolean } }[] };
+
+    const fp = doc.tasks.find(t => t.deterministic?.expect_skill_activation === false);
+    expect(fp).toBeDefined();
+    expect(fp!.expected_skill_load).toBe('none');
+  });
+
+  it('passes validateEvalFile', async () => {
+    const template = createEvalTemplate('my-skill', 5);
+    const tmpFile = path.join(os.tmpdir(), `parser-test-${Date.now()}.yaml`);
+    tmpFiles.push(tmpFile);
+
+    await fs.writeFile(tmpFile, template);
+    const errors = await validateEvalFile(tmpFile);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -202,7 +202,7 @@ program
   .description('Create an evaluation template for a skill')
   .argument('<skill_name>', 'Name of the skill')
   .option('-o, --output <path>', 'Output path for template')
-  .option('-n, --num-tasks <number>', 'Number of placeholder tasks', '10')
+  .option('-n, --num-tasks <number>', 'Total number of tasks to generate (includes 1 false-positive)', '10')
   .action(async (skillName: string, options: {
     output?: string;
     numTasks: string;
@@ -215,7 +215,8 @@ program
     const template = createEvalTemplate(skillName, numTasks);
     await fs.writeFile(outputPath, template);
 
-    console.log(`Created evaluation template: ${outputPath}`);
+    const numPositive = Math.max(1, numTasks - 1);
+    console.log(`Created evaluation template: ${outputPath} (${numPositive} positive tasks + 1 false-positive)`);
     console.log();
     console.log('Next steps:');
     console.log(`1. Edit ${outputPath} to add real evaluation tasks`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -202,13 +202,17 @@ program
   .description('Create an evaluation template for a skill')
   .argument('<skill_name>', 'Name of the skill')
   .option('-o, --output <path>', 'Output path for template')
-  .option('-n, --num-tasks <number>', 'Total number of tasks to generate (includes 1 false-positive)', '10')
+  .option('-n, --num-tasks <number>', 'Number of positive tasks to generate (1 false-positive is always added)', '10')
   .action(async (skillName: string, options: {
     output?: string;
     numTasks: string;
   }) => {
     const outputPath = options.output || path.join(process.cwd(), 'evals', skillName, 'tasks.yaml');
     const numTasks = parseInt(options.numTasks, 10);
+    if (isNaN(numTasks) || numTasks < 1) {
+      console.error('Error: --num-tasks must be a positive integer');
+      process.exit(1);
+    }
 
     await fs.mkdir(path.dirname(outputPath), { recursive: true });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -202,7 +202,7 @@ program
   .description('Create an evaluation template for a skill')
   .argument('<skill_name>', 'Name of the skill')
   .option('-o, --output <path>', 'Output path for template')
-  .option('-n, --num-tasks <number>', 'Number of positive tasks to generate (1 false-positive is always added)', '10')
+  .option('-n, --num-tasks <number>', 'Total number of tasks to generate (includes 1 false-positive)', '10')
   .action(async (skillName: string, options: {
     output?: string;
     numTasks: string;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -258,10 +258,13 @@ export async function validateEvalFile(filePath: string): Promise<string[]> {
  */
 export function createEvalTemplate(skillName: string, numTasks = 5): string {
   const prefix = skillName.slice(0, 2).toLowerCase();
+  const numPositive = Math.max(1, numTasks - 1);
 
-  const tasks = Array.from({ length: numTasks }, (_, i) => {
+  const tasks = Array.from({ length: numPositive }, (_, i) => {
     const taskId = `${prefix}-${String(i + 1).padStart(3, '0')}`;
     return `  - id: ${taskId}
+    # Tip: Vary phrasing and detail level across tasks. Use realistic context
+    # (file paths, column names) instead of generic placeholders.
     prompt: "TODO: Write a realistic prompt that should trigger ${skillName}"
     expected_skill_load: ${skillName}
     deterministic:
@@ -271,13 +274,27 @@ export function createEvalTemplate(skillName: string, numTasks = 5): string {
       discovery: { weight: 0.3, description: "Should load ${skillName} based on task context" }
       adherence: { weight: 0.4, description: "Should follow ${skillName} instructions" }
       output: { weight: 0.3, description: "Should produce quality output meeting requirements" }
+    # Tip: Write checklist items that are specific, observable, and verifiable.
+    # Good: "The output file is valid JSON" / Bad: "The output is good"
     golden_checklist:
-      - "TODO: Add expected behavior 1"
-      - "TODO: Add expected behavior 2"
-      - "TODO: Add expected behavior 3"`;
+      - "TODO: Add specific, verifiable expected behavior"
+      - "TODO: Add observable outcome that can be objectively checked"
+      - "TODO: Add countable or measurable requirement"`;
   });
 
-  return `skill: ${skillName}
+  // False-positive task: skill should NOT activate for this prompt
+  const fpTaskId = `${prefix}-fp-001`;
+  const fpTask = `  # False-positive test — include prompts that are similar but should NOT trigger the skill.
+  # These catch over-eager activation and are just as important as positive tests.
+  - id: ${fpTaskId}
+    prompt: "TODO: Write a prompt that is related but should NOT trigger ${skillName}"
+    expected_skill_load: none
+    deterministic:
+      expect_skill_activation: false`;
+
+  return `# Eval tasks for ${skillName}
+# See "Writing Effective Evals" in the README for test design tips.
+skill: ${skillName}
 version: "1.0"
 
 defaults:
@@ -289,5 +306,7 @@ defaults:
 
 tasks:
 ${tasks.join('\n\n')}
+
+${fpTask}
 `;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -284,13 +284,13 @@ export function createEvalTemplate(skillName: string, numTasks = 5): string {
 
   // False-positive task: skill should NOT activate for this prompt
   const fpTaskId = `${prefix}-fp-001`;
-  const fpTask = `  # False-positive test — include prompts that are similar but should NOT trigger the skill.
+  tasks.push(`  # False-positive test — include prompts that are similar but should NOT trigger the skill.
   # These catch over-eager activation and are just as important as positive tests.
   - id: ${fpTaskId}
     prompt: "TODO: Write a prompt that is related but should NOT trigger ${skillName}"
     expected_skill_load: none
     deterministic:
-      expect_skill_activation: false`;
+      expect_skill_activation: false`);
 
   return `# Eval tasks for ${skillName}
 # See "Writing Effective Evals" in the README for test design tips.
@@ -306,7 +306,5 @@ defaults:
 
 tasks:
 ${tasks.join('\n\n')}
-
-${fpTask}
 `;
 }


### PR DESCRIPTION
## Summary
- Add "Writing Effective Evals" section to README with practical guidance on test case design, golden checklist writing, skill improvement strategies, and scoring principles
- Update `create-eval` template with inline tips and an auto-generated false-positive task (counts toward `-n` total)
- Credit agentskills.io as the upstream source

Closes #25

## Test plan
- [ ] `npm run build` compiles without errors
- [ ] `skilljack-evals create-eval my-skill -n 3` generates 2 positive tasks + 1 false-positive task with inline tips
- [ ] `skilljack-evals validate` passes on the generated template
- [ ] Review README section for clarity and completeness against issue acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)