### PR TITLE
Add standard deviation reporting to multi-run aggregation

### DIFF
--- a/src/__tests__/aggregator.test.ts
+++ b/src/__tests__/aggregator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeStddev, aggregateScores, FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
-import type { CombinedScore } from '../types.js';
+import { computeSummary } from '../report/report.js';
+import type { CombinedScore, TaskResult } from '../types.js';
 
 describe('computeStddev', () => {
   it('returns 0 for empty array', () => {
@@ -61,9 +62,11 @@ describe('aggregateScores', () => {
     expect(aggregateScores([])).toEqual([]);
   });
 
-  it('returns original scores for single run', () => {
+  it('returns original scores for single run without stddev', () => {
     const scores = [makeScore()];
-    expect(aggregateScores([scores])).toBe(scores);
+    const result = aggregateScores([scores]);
+    expect(result).toBe(scores);
+    expect(result[0].stddev).toBeUndefined();
   });
 
   it('averages scores across runs', () => {
@@ -104,5 +107,92 @@ describe('aggregateScores', () => {
 describe('FLAKY_STDDEV_THRESHOLD', () => {
   it('is exported and equals 1.0', () => {
     expect(FLAKY_STDDEV_THRESHOLD).toBe(1.0);
+  });
+});
+
+describe('computeSummary', () => {
+  function makeResult(overrides: Partial<TaskResult> = {}): TaskResult {
+    return {
+      taskId: 'task-1',
+      prompt: 'test prompt',
+      output: 'test output',
+      durationMs: 1000,
+      numTurns: 1,
+      costUsd: 0.01,
+      skillLoads: [],
+      toolCalls: [],
+      isError: false,
+      errorMessage: '',
+      ...overrides,
+    };
+  }
+
+  function makeScore(overrides: Partial<CombinedScore> = {}): CombinedScore {
+    return {
+      taskId: 'task-1',
+      deterministic: null,
+      judge: null,
+      discovery: 1,
+      adherence: 4,
+      outputQuality: 4,
+      weightedScore: 0.8,
+      failureCategory: 'none',
+      reasoning: 'test',
+      ...overrides,
+    };
+  }
+
+  it('produces no stddev for single-run', () => {
+    const results = [makeResult()];
+    const scores = [makeScore()];
+    const summary = computeSummary(results, scores, 1);
+    expect(summary.stddev).toBeUndefined();
+  });
+
+  it('produces summary stddev as mean of per-task stddevs for multi-run', () => {
+    const results = [makeResult({ taskId: 'task-1' }), makeResult({ taskId: 'task-2' })];
+    const scores = [
+      makeScore({
+        taskId: 'task-1',
+        stddev: { discovery: 0.2, adherence: 0.5, outputQuality: 0.6, weightedScore: 0.1 },
+      }),
+      makeScore({
+        taskId: 'task-2',
+        stddev: { discovery: 0.4, adherence: 1.5, outputQuality: 1.0, weightedScore: 0.3 },
+      }),
+    ];
+    const summary = computeSummary(results, scores, 3);
+
+    expect(summary.stddev).toBeDefined();
+    expect(summary.stddev!.discovery).toBeCloseTo(0.3, 10);
+    expect(summary.stddev!.adherence).toBeCloseTo(1.0, 10);
+    expect(summary.stddev!.outputQuality).toBeCloseTo(0.8, 10);
+    expect(summary.stddev!.weightedScore).toBeCloseTo(0.2, 10);
+  });
+
+  it('handles mix of tasks with and without stddev', () => {
+    const results = [makeResult({ taskId: 'task-1' }), makeResult({ taskId: 'task-2' })];
+    const scores = [
+      makeScore({
+        taskId: 'task-1',
+        stddev: { discovery: 0.2, adherence: 0.8, outputQuality: 0.6, weightedScore: 0.1 },
+      }),
+      makeScore({ taskId: 'task-2' }), // no stddev
+    ];
+    const summary = computeSummary(results, scores, 2);
+
+    // Only one task has stddev, so summary stddev should equal that task's stddev
+    expect(summary.stddev).toBeDefined();
+    expect(summary.stddev!.discovery).toBeCloseTo(0.2, 10);
+    expect(summary.stddev!.adherence).toBeCloseTo(0.8, 10);
+    expect(summary.stddev!.outputQuality).toBeCloseTo(0.6, 10);
+    expect(summary.stddev!.weightedScore).toBeCloseTo(0.1, 10);
+  });
+
+  it('produces no stddev when numRuns >= 2 but no tasks have stddev', () => {
+    const results = [makeResult()];
+    const scores = [makeScore()]; // no stddev property
+    const summary = computeSummary(results, scores, 2);
+    expect(summary.stddev).toBeUndefined();
   });
 });

--- a/src/__tests__/aggregator.test.ts
+++ b/src/__tests__/aggregator.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { computeStddev, aggregateScores, FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
+import type { CombinedScore } from '../types.js';
+
+describe('computeStddev', () => {
+  it('returns 0 for empty array', () => {
+    expect(computeStddev([])).toBe(0);
+  });
+
+  it('returns 0 for single value', () => {
+    expect(computeStddev([5])).toBe(0);
+  });
+
+  it('returns 0 for identical values', () => {
+    expect(computeStddev([3, 3, 3, 3])).toBe(0);
+  });
+
+  it('computes correct sample stddev for two values', () => {
+    // [2, 4] -> mean=3, variance=((2-3)^2+(4-3)^2)/1=2, stddev=sqrt(2)
+    expect(computeStddev([2, 4])).toBeCloseTo(Math.SQRT2, 10);
+  });
+
+  it('computes correct sample stddev for known dataset', () => {
+    // [2, 4, 4, 4, 5, 5, 7, 9] -> mean=5, sample stddev ~2.138
+    const values = [2, 4, 4, 4, 5, 5, 7, 9];
+    const expected = Math.sqrt(((2-5)**2 + (4-5)**2 + (4-5)**2 + (4-5)**2 + (5-5)**2 + (5-5)**2 + (7-5)**2 + (9-5)**2) / 7);
+    expect(computeStddev(values)).toBeCloseTo(expected, 10);
+  });
+
+  it('uses provided mean when given', () => {
+    const values = [2, 4];
+    const result = computeStddev(values, 3);
+    expect(result).toBeCloseTo(Math.SQRT2, 10);
+  });
+
+  it('computes mean internally when not provided', () => {
+    const values = [2, 4];
+    const withMean = computeStddev(values, 3);
+    const withoutMean = computeStddev(values);
+    expect(withoutMean).toBeCloseTo(withMean, 10);
+  });
+});
+
+describe('aggregateScores', () => {
+  function makeScore(overrides: Partial<CombinedScore> = {}): CombinedScore {
+    return {
+      taskId: 'task-1',
+      deterministic: null,
+      judge: null,
+      discovery: 1,
+      adherence: 4,
+      outputQuality: 4,
+      weightedScore: 0.8,
+      failureCategory: 'none',
+      reasoning: 'test',
+      ...overrides,
+    };
+  }
+
+  it('returns empty array for no runs', () => {
+    expect(aggregateScores([])).toEqual([]);
+  });
+
+  it('returns original scores for single run', () => {
+    const scores = [makeScore()];
+    expect(aggregateScores([scores])).toBe(scores);
+  });
+
+  it('averages scores across runs', () => {
+    const run1 = [makeScore({ adherence: 3, outputQuality: 3, weightedScore: 0.6 })];
+    const run2 = [makeScore({ adherence: 5, outputQuality: 5, weightedScore: 1.0 })];
+    const result = aggregateScores([run1, run2]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].adherence).toBe(4);
+    expect(result[0].outputQuality).toBe(4);
+    expect(result[0].weightedScore).toBe(0.8);
+  });
+
+  it('populates stddev for multi-run aggregation', () => {
+    const run1 = [makeScore({ adherence: 3, outputQuality: 3 })];
+    const run2 = [makeScore({ adherence: 5, outputQuality: 5 })];
+    const result = aggregateScores([run1, run2]);
+
+    expect(result[0].stddev).toBeDefined();
+    expect(result[0].stddev!.adherence).toBeGreaterThan(0);
+    expect(result[0].stddev!.outputQuality).toBeGreaterThan(0);
+  });
+
+  it('produces zero stddev when all runs are identical', () => {
+    const run1 = [makeScore()];
+    const run2 = [makeScore()];
+    const run3 = [makeScore()];
+    const result = aggregateScores([run1, run2, run3]);
+
+    expect(result[0].stddev).toBeDefined();
+    expect(result[0].stddev!.discovery).toBeCloseTo(0, 10);
+    expect(result[0].stddev!.adherence).toBeCloseTo(0, 10);
+    expect(result[0].stddev!.outputQuality).toBeCloseTo(0, 10);
+    expect(result[0].stddev!.weightedScore).toBeCloseTo(0, 10);
+  });
+});
+
+describe('FLAKY_STDDEV_THRESHOLD', () => {
+  it('is exported and equals 1.0', () => {
+    expect(FLAKY_STDDEV_THRESHOLD).toBe(1.0);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export type {
   JudgeScore,
   JudgeOptions,
   CombinedScore,
+  ScoreStddev,
   SessionLogEntry,
   MetricsData,
   SessionLog,
@@ -49,7 +50,7 @@ export { createToolPolicy } from './runner/security.js';
 export { scoreTask, scoreAll } from './scorer/scorer.js';
 export { scoreDeterministic } from './scorer/deterministic.js';
 export { SkillJudge } from './scorer/judge.js';
-export { aggregateResults, aggregateScores } from './scorer/aggregator.js';
+export { aggregateResults, aggregateScores, computeStddev } from './scorer/aggregator.js';
 
 // Session
 export { SessionLogger } from './session/session-logger.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export { createToolPolicy } from './runner/security.js';
 export { scoreTask, scoreAll } from './scorer/scorer.js';
 export { scoreDeterministic } from './scorer/deterministic.js';
 export { SkillJudge } from './scorer/judge.js';
-export { aggregateResults, aggregateScores, computeStddev } from './scorer/aggregator.js';
+export { aggregateResults, aggregateScores, computeStddev, FLAKY_STDDEV_THRESHOLD } from './scorer/aggregator.js';
 
 // Session
 export { SessionLogger } from './session/session-logger.js';

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -295,10 +295,10 @@ function printSummary(report: EvaluationReport): void {
   if (s.numRuns > 1) {
     console.log(`  Runs: ${s.numRuns}`);
   }
-  console.log(`  Discovery: ${(s.discoveryAccuracy * 100).toFixed(0)}%`);
-  console.log(`  Avg Adherence: ${s.avgAdherence.toFixed(2)}/5${s.stddev ? ` (\u00B1${s.stddev.adherence.toFixed(2)})` : ''}`);
-  console.log(`  Avg Output Quality: ${s.avgOutputQuality.toFixed(2)}/5${s.stddev ? ` (\u00B1${s.stddev.outputQuality.toFixed(2)})` : ''}`);
-  console.log(`  Weighted Score: ${s.avgWeightedScore.toFixed(2)}${s.stddev ? ` (\u00B1${s.stddev.weightedScore.toFixed(2)})` : ''}`);
+  console.log(`  Discovery: ${(s.discoveryAccuracy * 100).toFixed(0)}%${s.stddev ? ` (\u00B1 ${(s.stddev.discovery * 100).toFixed(1)}%)` : ''}`);
+  console.log(`  Avg Adherence: ${s.avgAdherence.toFixed(2)}/5${s.stddev ? ` (\u00B1 ${s.stddev.adherence.toFixed(2)})` : ''}`);
+  console.log(`  Avg Output Quality: ${s.avgOutputQuality.toFixed(2)}/5${s.stddev ? ` (\u00B1 ${s.stddev.outputQuality.toFixed(2)})` : ''}`);
+  console.log(`  Weighted Score: ${s.avgWeightedScore.toFixed(2)}${s.stddev ? ` (\u00B1 ${s.stddev.weightedScore.toFixed(2)})` : ''}`);
   console.log(`  Duration: ${(s.totalDurationMs / 1000).toFixed(1)}s | Cost: $${s.totalCostUsd.toFixed(4)}`);
   if (!report.passed && report.failureReasons.length > 0) {
     console.log(`\n  Failures:`);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -296,9 +296,9 @@ function printSummary(report: EvaluationReport): void {
     console.log(`  Runs: ${s.numRuns}`);
   }
   console.log(`  Discovery: ${(s.discoveryAccuracy * 100).toFixed(0)}%`);
-  console.log(`  Avg Adherence: ${s.avgAdherence.toFixed(2)}/5`);
-  console.log(`  Avg Output Quality: ${s.avgOutputQuality.toFixed(2)}/5`);
-  console.log(`  Weighted Score: ${s.avgWeightedScore.toFixed(2)}`);
+  console.log(`  Avg Adherence: ${s.avgAdherence.toFixed(2)}/5${s.stddev ? ` (\u00B1${s.stddev.adherence.toFixed(2)})` : ''}`);
+  console.log(`  Avg Output Quality: ${s.avgOutputQuality.toFixed(2)}/5${s.stddev ? ` (\u00B1${s.stddev.outputQuality.toFixed(2)})` : ''}`);
+  console.log(`  Weighted Score: ${s.avgWeightedScore.toFixed(2)}${s.stddev ? ` (\u00B1${s.stddev.weightedScore.toFixed(2)})` : ''}`);
   console.log(`  Duration: ${(s.totalDurationMs / 1000).toFixed(1)}s | Cost: $${s.totalCostUsd.toFixed(4)}`);
   if (!report.passed && report.failureReasons.length > 0) {
     console.log(`\n  Failures:`);

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -66,6 +66,8 @@ export function generateGitHubSummary(report: EvaluationReport): string {
     const s = t.score;
     const status = s.failureCategory === 'none' ? 'PASS' : 'FAIL';
     if (isMultiRun) {
+      // Only check adherence and outputQuality against the threshold since they
+      // use the 1-5 scale. Discovery (0/1) and weightedScore (0-1) cannot exceed 1.0.
       const varianceLabel = s.stddev
         ? (s.stddev.adherence > FLAKY_STDDEV_THRESHOLD || s.stddev.outputQuality > FLAKY_STDDEV_THRESHOLD ? ':warning: High' : 'Low')
         : 'N/A';

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -73,7 +73,7 @@ export function generateGitHubSummary(report: EvaluationReport): string {
         : 'N/A';
       lines.push(`| ${t.task.id} | ${(s.discovery * 100).toFixed(0)}% | ${s.adherence.toFixed(1)}/5 | ${s.outputQuality.toFixed(1)}/5 | ${s.weightedScore.toFixed(2)} | ${varianceLabel} | ${status} |`);
     } else {
-      lines.push(`| ${t.task.id} | ${s.discovery} | ${s.adherence}/5 | ${s.outputQuality}/5 | ${s.weightedScore.toFixed(2)} | ${status} |`);
+      lines.push(`| ${t.task.id} | ${(s.discovery * 100).toFixed(0)}% | ${s.adherence.toFixed(1)}/5 | ${s.outputQuality.toFixed(1)}/5 | ${s.weightedScore.toFixed(2)} | ${status} |`);
     }
   }
   lines.push('');

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -11,6 +11,7 @@ import type {
   FailureBreakdown,
   CombinedScore,
 } from '../types.js';
+import { FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
 
 /**
  * Generate a condensed summary for GitHub Actions.
@@ -64,9 +65,10 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   for (const t of tasks) {
     const s = t.score;
     const status = s.failureCategory === 'none' ? 'PASS' : 'FAIL';
-    if (isMultiRun && s.stddev) {
-      const isFlaky = s.stddev.adherence > 1.0 || s.stddev.outputQuality > 1.0;
-      const varianceLabel = isFlaky ? ':warning: High' : 'Low';
+    if (isMultiRun) {
+      const varianceLabel = s.stddev
+        ? (s.stddev.adherence > FLAKY_STDDEV_THRESHOLD || s.stddev.outputQuality > FLAKY_STDDEV_THRESHOLD ? ':warning: High' : 'Low')
+        : 'N/A';
       lines.push(`| ${t.task.id} | ${s.discovery.toFixed(1)} | ${s.adherence.toFixed(1)}/5 | ${s.outputQuality.toFixed(1)}/5 | ${s.weightedScore.toFixed(2)} | ${varianceLabel} | ${status} |`);
     } else {
       lines.push(`| ${t.task.id} | ${s.discovery} | ${s.adherence}/5 | ${s.outputQuality}/5 | ${s.weightedScore.toFixed(2)} | ${status} |`);

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -71,7 +71,7 @@ export function generateGitHubSummary(report: EvaluationReport): string {
       const varianceLabel = s.stddev
         ? (s.stddev.adherence > FLAKY_STDDEV_THRESHOLD || s.stddev.outputQuality > FLAKY_STDDEV_THRESHOLD ? ':warning: High' : 'Low')
         : 'N/A';
-      lines.push(`| ${t.task.id} | ${s.discovery.toFixed(1)} | ${s.adherence.toFixed(1)}/5 | ${s.outputQuality.toFixed(1)}/5 | ${s.weightedScore.toFixed(2)} | ${varianceLabel} | ${status} |`);
+      lines.push(`| ${t.task.id} | ${(s.discovery * 100).toFixed(0)}% | ${s.adherence.toFixed(1)}/5 | ${s.outputQuality.toFixed(1)}/5 | ${s.weightedScore.toFixed(2)} | ${varianceLabel} | ${status} |`);
     } else {
       lines.push(`| ${t.task.id} | ${s.discovery} | ${s.adherence}/5 | ${s.outputQuality}/5 | ${s.weightedScore.toFixed(2)} | ${status} |`);
     }

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -28,9 +28,9 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   lines.push('| Metric | Value | Status |');
   lines.push('|--------|-------|--------|');
   lines.push(`| Discovery Rate | ${(summary.discoveryAccuracy * 100).toFixed(0)}% (${Math.round(summary.discoveryAccuracy * summary.totalTasks)}/${summary.totalTasks}) | ${summary.discoveryAccuracy >= 0.8 ? 'PASS' : 'FAIL'} |`);
-  lines.push(`| Avg Adherence | ${summary.avgAdherence.toFixed(1)}/5 | ${summary.avgAdherence >= 4.0 ? 'PASS' : 'FAIL'} |`);
-  lines.push(`| Avg Output Quality | ${summary.avgOutputQuality.toFixed(1)}/5 | ${summary.avgOutputQuality >= 4.0 ? 'PASS' : 'FAIL'} |`);
-  lines.push(`| Weighted Score | ${summary.avgWeightedScore.toFixed(2)} | |`);
+  lines.push(`| Avg Adherence | ${summary.avgAdherence.toFixed(1)}/5${summary.stddev ? ` \u00B1 ${summary.stddev.adherence.toFixed(1)}` : ''} | ${summary.avgAdherence >= 4.0 ? 'PASS' : 'FAIL'} |`);
+  lines.push(`| Avg Output Quality | ${summary.avgOutputQuality.toFixed(1)}/5${summary.stddev ? ` \u00B1 ${summary.stddev.outputQuality.toFixed(1)}` : ''} | ${summary.avgOutputQuality >= 4.0 ? 'PASS' : 'FAIL'} |`);
+  lines.push(`| Weighted Score | ${summary.avgWeightedScore.toFixed(2)}${summary.stddev ? ` \u00B1 ${summary.stddev.weightedScore.toFixed(2)}` : ''} | |`);
   lines.push(`| Duration | ${(summary.totalDurationMs / 1000).toFixed(1)}s | |`);
   lines.push(`| Cost | $${summary.totalCostUsd.toFixed(4)} | |`);
   lines.push('');
@@ -51,14 +51,26 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   }
 
   // Per-task details in collapsible
+  const isMultiRun = summary.numRuns > 1;
   lines.push('<details><summary>All task results</summary>');
   lines.push('');
-  lines.push('| Task | Discovery | Adherence | Output | Weighted | Status |');
-  lines.push('|------|-----------|-----------|--------|----------|--------|');
+  if (isMultiRun) {
+    lines.push('| Task | Discovery | Adherence | Output | Weighted | Variance | Status |');
+    lines.push('|------|-----------|-----------|--------|----------|----------|--------|');
+  } else {
+    lines.push('| Task | Discovery | Adherence | Output | Weighted | Status |');
+    lines.push('|------|-----------|-----------|--------|----------|--------|');
+  }
   for (const t of tasks) {
     const s = t.score;
     const status = s.failureCategory === 'none' ? 'PASS' : 'FAIL';
-    lines.push(`| ${t.task.id} | ${s.discovery} | ${s.adherence}/5 | ${s.outputQuality}/5 | ${s.weightedScore.toFixed(2)} | ${status} |`);
+    if (isMultiRun && s.stddev) {
+      const isFlaky = s.stddev.adherence > 1.0 || s.stddev.outputQuality > 1.0;
+      const varianceLabel = isFlaky ? ':warning: High' : 'Low';
+      lines.push(`| ${t.task.id} | ${s.discovery.toFixed(1)} | ${s.adherence.toFixed(1)}/5 | ${s.outputQuality.toFixed(1)}/5 | ${s.weightedScore.toFixed(2)} | ${varianceLabel} | ${status} |`);
+    } else {
+      lines.push(`| ${t.task.id} | ${s.discovery} | ${s.adherence}/5 | ${s.outputQuality}/5 | ${s.weightedScore.toFixed(2)} | ${status} |`);
+    }
   }
   lines.push('');
   lines.push('</details>');

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -28,7 +28,7 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   // Summary table
   lines.push('| Metric | Value | Status |');
   lines.push('|--------|-------|--------|');
-  lines.push(`| Discovery Rate | ${(summary.discoveryAccuracy * 100).toFixed(0)}% (${Math.round(summary.discoveryAccuracy * summary.totalTasks)}/${summary.totalTasks}) | ${summary.discoveryAccuracy >= 0.8 ? 'PASS' : 'FAIL'} |`);
+  lines.push(`| Discovery Rate | ${(summary.discoveryAccuracy * 100).toFixed(0)}%${summary.stddev ? ` \u00B1 ${(summary.stddev.discovery * 100).toFixed(0)}%` : ''} (${Math.round(summary.discoveryAccuracy * summary.totalTasks)}/${summary.totalTasks}) | ${summary.discoveryAccuracy >= 0.8 ? 'PASS' : 'FAIL'} |`);
   lines.push(`| Avg Adherence | ${summary.avgAdherence.toFixed(1)}/5${summary.stddev ? ` \u00B1 ${summary.stddev.adherence.toFixed(1)}` : ''} | ${summary.avgAdherence >= 4.0 ? 'PASS' : 'FAIL'} |`);
   lines.push(`| Avg Output Quality | ${summary.avgOutputQuality.toFixed(1)}/5${summary.stddev ? ` \u00B1 ${summary.stddev.outputQuality.toFixed(1)}` : ''} | ${summary.avgOutputQuality >= 4.0 ? 'PASS' : 'FAIL'} |`);
   lines.push(`| Weighted Score | ${summary.avgWeightedScore.toFixed(2)}${summary.stddev ? ` \u00B1 ${summary.stddev.weightedScore.toFixed(2)}` : ''} | |`);

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -17,7 +17,7 @@ import type {
   ReportMetadata,
 } from '../types.js';
 import { loadConfigSync } from '../config.js';
-import { computeStddev, FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
+import { FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
 
 /**
  * Generate a markdown report from evaluation results.
@@ -109,11 +109,12 @@ ${metaSection}
 
 | Dimension | Score | Status |
 |-----------|-------|--------|
-| Discovery | ${Math.round(score.discovery)}${score.stddev ? ` \u00B1 ${(score.stddev.discovery * 100).toFixed(0)}%` : ''} | ${score.discovery >= 1 ? 'PASS' : 'FAIL'} |
+| Discovery | ${score.stddev ? `${(score.discovery * 100).toFixed(0)}% \u00B1 ${(score.stddev.discovery * 100).toFixed(0)}%` : `${Math.round(score.discovery)}`} | ${score.discovery >= 1 ? 'PASS' : 'FAIL'} |
 | Adherence | ${score.adherence.toFixed(1)}/5${score.stddev ? ` \u00B1 ${score.stddev.adherence.toFixed(1)}` : ''} | ${score.adherence >= 4 ? 'PASS' : 'FAIL'} |
 | Output Quality | ${score.outputQuality.toFixed(1)}/5${score.stddev ? ` \u00B1 ${score.stddev.outputQuality.toFixed(1)}` : ''} | ${score.outputQuality >= 4 ? 'PASS' : 'FAIL'} |
 | **Weighted** | **${score.weightedScore.toFixed(2)}${score.stddev ? ` \u00B1 ${score.stddev.weightedScore.toFixed(2)}` : ''}** | |
-${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stddev.outputQuality > FLAKY_STDDEV_THRESHOLD) ? `\n> **Warning: Potentially Flaky** \u2014 High variance across runs (adherence \u03C3=${score.stddev.adherence.toFixed(2)}, output \u03C3=${score.stddev.outputQuality.toFixed(2)})\n` : ''}
+${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stddev.outputQuality > FLAKY_STDDEV_THRESHOLD) ? `\n> **Warning: Potentially Flaky** \u2014 High variance across runs (adherence \u03C3=${score.stddev.adherence.toFixed(2)}, output \u03C3=${score.stddev.outputQuality.toFixed(2)})
+> _Only adherence and output quality are checked: discovery (0/1) and weighted score (0-1) cannot exceed the threshold._\n` : ''}
 **Failure Category:** ${formatCategory(score.failureCategory)}
 `;
 
@@ -276,7 +277,8 @@ export function computeSummary(
   };
 
   // Compute summary-level stddev as the mean of per-task stddevs (cross-run variability).
-  // This tells users "on average, how much do scores vary across runs."
+  // Note: this is an average of stddevs, not a true pooled stddev. It answers
+  // "on average, how much do individual task scores vary across runs."
   if (numRuns >= 2) {
     const tasksWithStddev = scores.filter(s => s.stddev);
     if (tasksWithStddev.length > 0) {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -109,7 +109,7 @@ ${metaSection}
 
 | Dimension | Score | Status |
 |-----------|-------|--------|
-| Discovery | ${Math.round(score.discovery)}${score.stddev ? ` \u00B1 ${score.stddev.discovery.toFixed(2)}` : ''} | ${score.discovery >= 1 ? 'PASS' : 'FAIL'} |
+| Discovery | ${Math.round(score.discovery)}${score.stddev ? ` \u00B1 ${(score.stddev.discovery * 100).toFixed(0)}%` : ''} | ${score.discovery >= 1 ? 'PASS' : 'FAIL'} |
 | Adherence | ${score.adherence.toFixed(1)}/5${score.stddev ? ` \u00B1 ${score.stddev.adherence.toFixed(1)}` : ''} | ${score.adherence >= 4 ? 'PASS' : 'FAIL'} |
 | Output Quality | ${score.outputQuality.toFixed(1)}/5${score.stddev ? ` \u00B1 ${score.stddev.outputQuality.toFixed(1)}` : ''} | ${score.outputQuality >= 4 ? 'PASS' : 'FAIL'} |
 | **Weighted** | **${score.weightedScore.toFixed(2)}${score.stddev ? ` \u00B1 ${score.stddev.weightedScore.toFixed(2)}` : ''}** | |
@@ -275,17 +275,18 @@ export function computeSummary(
     totalCostUsd: results.reduce((sum, r) => sum + r.costUsd, 0),
   };
 
-  // Compute summary-level stddev across per-task mean scores when multi-run.
-  // Note: this measures variance across tasks (how spread are per-task averages),
-  // whereas task-level stddev measures variance across runs for a single task.
-  // With a single task, all stddev values will be 0 (no cross-task spread).
+  // Compute summary-level stddev as the mean of per-task stddevs (cross-run variability).
+  // This tells users "on average, how much do scores vary across runs."
   if (numRuns >= 2) {
-    summary.stddev = {
-      discovery: computeStddev(scores.map(s => s.discovery), avgDiscovery),
-      adherence: computeStddev(scores.map(s => s.adherence), avgAdherence),
-      outputQuality: computeStddev(scores.map(s => s.outputQuality), avgOutputQuality),
-      weightedScore: computeStddev(scores.map(s => s.weightedScore), avgWeightedScore),
-    };
+    const tasksWithStddev = scores.filter(s => s.stddev);
+    if (tasksWithStddev.length > 0) {
+      summary.stddev = {
+        discovery: tasksWithStddev.reduce((sum, s) => sum + s.stddev!.discovery, 0) / tasksWithStddev.length,
+        adherence: tasksWithStddev.reduce((sum, s) => sum + s.stddev!.adherence, 0) / tasksWithStddev.length,
+        outputQuality: tasksWithStddev.reduce((sum, s) => sum + s.stddev!.outputQuality, 0) / tasksWithStddev.length,
+        weightedScore: tasksWithStddev.reduce((sum, s) => sum + s.stddev!.weightedScore, 0) / tasksWithStddev.length,
+      };
+    }
   }
 
   return summary;

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -17,6 +17,7 @@ import type {
   ReportMetadata,
 } from '../types.js';
 import { loadConfigSync } from '../config.js';
+import { computeStddev } from '../scorer/aggregator.js';
 
 /**
  * Generate a markdown report from evaluation results.
@@ -68,10 +69,10 @@ ${metaSection}
 
 | Metric | Value | Threshold | Status |
 |--------|-------|-----------|--------|
-| **Discovery Accuracy** | ${(summary.discoveryAccuracy * 100).toFixed(1)}% | ${(config.discoveryThreshold * 100).toFixed(0)}% | ${discoveryPassed ? 'PASS' : 'FAIL'} |
-| **Avg Adherence Score** | ${summary.avgAdherence.toFixed(2)}/5.0 | ${config.scoreThreshold.toFixed(1)} | ${summary.avgAdherence >= config.scoreThreshold ? 'PASS' : 'FAIL'} |
-| **Avg Output Quality** | ${summary.avgOutputQuality.toFixed(2)}/5.0 | ${config.scoreThreshold.toFixed(1)} | ${summary.avgOutputQuality >= config.scoreThreshold ? 'PASS' : 'FAIL'} |
-| **Avg Weighted Score** | ${summary.avgWeightedScore.toFixed(2)} | | |
+| **Discovery Accuracy** | ${(summary.discoveryAccuracy * 100).toFixed(1)}%${summary.stddev ? ` \u00B1 ${(summary.stddev.discovery * 100).toFixed(1)}%` : ''} | ${(config.discoveryThreshold * 100).toFixed(0)}% | ${discoveryPassed ? 'PASS' : 'FAIL'} |
+| **Avg Adherence Score** | ${summary.avgAdherence.toFixed(2)}/5.0${summary.stddev ? ` \u00B1 ${summary.stddev.adherence.toFixed(2)}` : ''} | ${config.scoreThreshold.toFixed(1)} | ${summary.avgAdherence >= config.scoreThreshold ? 'PASS' : 'FAIL'} |
+| **Avg Output Quality** | ${summary.avgOutputQuality.toFixed(2)}/5.0${summary.stddev ? ` \u00B1 ${summary.stddev.outputQuality.toFixed(2)}` : ''} | ${config.scoreThreshold.toFixed(1)} | ${summary.avgOutputQuality >= config.scoreThreshold ? 'PASS' : 'FAIL'} |
+| **Avg Weighted Score** | ${summary.avgWeightedScore.toFixed(2)}${summary.stddev ? ` \u00B1 ${summary.stddev.weightedScore.toFixed(2)}` : ''} | | |
 | **Total Duration** | ${(summary.totalDurationMs / 1000).toFixed(1)}s | | |
 | **Total Cost** | $${summary.totalCostUsd.toFixed(4)} | | |
 
@@ -108,11 +109,11 @@ ${metaSection}
 
 | Dimension | Score | Status |
 |-----------|-------|--------|
-| Discovery | ${Math.round(score.discovery)} | ${score.discovery >= 1 ? 'PASS' : 'FAIL'} |
-| Adherence | ${score.adherence}/5 | ${score.adherence >= 4 ? 'PASS' : 'FAIL'} |
-| Output Quality | ${score.outputQuality}/5 | ${score.outputQuality >= 4 ? 'PASS' : 'FAIL'} |
-| **Weighted** | **${score.weightedScore.toFixed(2)}** | |
-
+| Discovery | ${Math.round(score.discovery)}${score.stddev ? ` \u00B1 ${score.stddev.discovery.toFixed(2)}` : ''} | ${score.discovery >= 1 ? 'PASS' : 'FAIL'} |
+| Adherence | ${score.adherence.toFixed(1)}/5${score.stddev ? ` \u00B1 ${score.stddev.adherence.toFixed(1)}` : ''} | ${score.adherence >= 4 ? 'PASS' : 'FAIL'} |
+| Output Quality | ${score.outputQuality.toFixed(1)}/5${score.stddev ? ` \u00B1 ${score.stddev.outputQuality.toFixed(1)}` : ''} | ${score.outputQuality >= 4 ? 'PASS' : 'FAIL'} |
+| **Weighted** | **${score.weightedScore.toFixed(2)}${score.stddev ? ` \u00B1 ${score.stddev.weightedScore.toFixed(2)}` : ''}** | |
+${score.stddev && (score.stddev.adherence > 1.0 || score.stddev.outputQuality > 1.0) ? `\n> **Warning: Potentially Flaky** \u2014 High variance across runs (adherence \u03C3=${score.stddev.adherence.toFixed(2)}, output \u03C3=${score.stddev.outputQuality.toFixed(2)})\n` : ''}
 **Failure Category:** ${formatCategory(score.failureCategory)}
 `;
 
@@ -253,22 +254,38 @@ export function computeSummary(
     ? scores.reduce((sum, s) => sum + s.discovery, 0) / totalTasks
     : 0;
 
-  return {
+  const avgAdherence = totalTasks > 0
+    ? scores.reduce((sum, s) => sum + s.adherence, 0) / totalTasks
+    : 0;
+  const avgOutputQuality = totalTasks > 0
+    ? scores.reduce((sum, s) => sum + s.outputQuality, 0) / totalTasks
+    : 0;
+  const avgWeightedScore = totalTasks > 0
+    ? scores.reduce((sum, s) => sum + s.weightedScore, 0) / totalTasks
+    : 0;
+
+  const summary: EvaluationSummary = {
     totalTasks,
     numRuns,
     discoveryAccuracy: avgDiscovery,
-    avgAdherence: totalTasks > 0
-      ? scores.reduce((sum, s) => sum + s.adherence, 0) / totalTasks
-      : 0,
-    avgOutputQuality: totalTasks > 0
-      ? scores.reduce((sum, s) => sum + s.outputQuality, 0) / totalTasks
-      : 0,
-    avgWeightedScore: totalTasks > 0
-      ? scores.reduce((sum, s) => sum + s.weightedScore, 0) / totalTasks
-      : 0,
+    avgAdherence,
+    avgOutputQuality,
+    avgWeightedScore,
     totalDurationMs: results.reduce((sum, r) => sum + r.durationMs, 0),
     totalCostUsd: results.reduce((sum, r) => sum + r.costUsd, 0),
   };
+
+  // Compute summary-level stddev across per-task scores when multi-run
+  if (numRuns >= 2 && totalTasks >= 2) {
+    summary.stddev = {
+      discovery: computeStddev(scores.map(s => s.discovery), avgDiscovery),
+      adherence: computeStddev(scores.map(s => s.adherence), avgAdherence),
+      outputQuality: computeStddev(scores.map(s => s.outputQuality), avgOutputQuality),
+      weightedScore: computeStddev(scores.map(s => s.weightedScore), avgWeightedScore),
+    };
+  }
+
+  return summary;
 }
 
 /**

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -17,7 +17,7 @@ import type {
   ReportMetadata,
 } from '../types.js';
 import { loadConfigSync } from '../config.js';
-import { computeStddev } from '../scorer/aggregator.js';
+import { computeStddev, FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
 
 /**
  * Generate a markdown report from evaluation results.
@@ -113,7 +113,7 @@ ${metaSection}
 | Adherence | ${score.adherence.toFixed(1)}/5${score.stddev ? ` \u00B1 ${score.stddev.adherence.toFixed(1)}` : ''} | ${score.adherence >= 4 ? 'PASS' : 'FAIL'} |
 | Output Quality | ${score.outputQuality.toFixed(1)}/5${score.stddev ? ` \u00B1 ${score.stddev.outputQuality.toFixed(1)}` : ''} | ${score.outputQuality >= 4 ? 'PASS' : 'FAIL'} |
 | **Weighted** | **${score.weightedScore.toFixed(2)}${score.stddev ? ` \u00B1 ${score.stddev.weightedScore.toFixed(2)}` : ''}** | |
-${score.stddev && (score.stddev.adherence > 1.0 || score.stddev.outputQuality > 1.0) ? `\n> **Warning: Potentially Flaky** \u2014 High variance across runs (adherence \u03C3=${score.stddev.adherence.toFixed(2)}, output \u03C3=${score.stddev.outputQuality.toFixed(2)})\n` : ''}
+${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stddev.outputQuality > FLAKY_STDDEV_THRESHOLD) ? `\n> **Warning: Potentially Flaky** \u2014 High variance across runs (adherence \u03C3=${score.stddev.adherence.toFixed(2)}, output \u03C3=${score.stddev.outputQuality.toFixed(2)})\n` : ''}
 **Failure Category:** ${formatCategory(score.failureCategory)}
 `;
 
@@ -275,8 +275,11 @@ export function computeSummary(
     totalCostUsd: results.reduce((sum, r) => sum + r.costUsd, 0),
   };
 
-  // Compute summary-level stddev across per-task scores when multi-run
-  if (numRuns >= 2 && totalTasks >= 2) {
+  // Compute summary-level stddev across per-task mean scores when multi-run.
+  // Note: this measures variance across tasks (how spread are per-task averages),
+  // whereas task-level stddev measures variance across runs for a single task.
+  // With a single task, all stddev values will be 0 (no cross-task spread).
+  if (numRuns >= 2) {
     summary.stddev = {
       discovery: computeStddev(scores.map(s => s.discovery), avgDiscovery),
       adherence: computeStddev(scores.map(s => s.adherence), avgAdherence),

--- a/src/scorer/aggregator.ts
+++ b/src/scorer/aggregator.ts
@@ -4,7 +4,17 @@
  * Merges N independent runs per task into single averaged results and scores.
  */
 
-import type { TaskResult, CombinedScore, FailureCategory } from '../types.js';
+import type { TaskResult, CombinedScore, FailureCategory, ScoreStddev } from '../types.js';
+
+/**
+ * Compute sample standard deviation (N-1 denominator).
+ * Returns 0 when fewer than 2 values are provided.
+ */
+export function computeStddev(values: number[], mean: number): number {
+  if (values.length < 2) return 0;
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
 
 /**
  * Aggregate multiple runs of TaskResult[] into a single TaskResult per task.
@@ -78,6 +88,14 @@ export function aggregateScores(allScores: CombinedScore[][]): CombinedScore[] {
     const avgOutput = scores.reduce((sum, s) => sum + s.outputQuality, 0) / numRuns;
     const avgWeighted = scores.reduce((sum, s) => sum + s.weightedScore, 0) / numRuns;
 
+    // Compute sample standard deviations
+    const stddev: ScoreStddev = {
+      discovery: computeStddev(scores.map(s => s.discovery), avgDiscovery),
+      adherence: computeStddev(scores.map(s => s.adherence), avgAdherence),
+      outputQuality: computeStddev(scores.map(s => s.outputQuality), avgOutput),
+      weightedScore: computeStddev(scores.map(s => s.weightedScore), avgWeighted),
+    };
+
     // Mode of failure categories
     const catCounts = new Map<FailureCategory, number>();
     for (const s of scores) {
@@ -104,6 +122,7 @@ export function aggregateScores(allScores: CombinedScore[][]): CombinedScore[] {
       weightedScore: avgWeighted,
       failureCategory: modeCategory,
       reasoning: `Aggregated over ${numRuns} runs: discovery ${discoveryCount}/${numRuns}, mean adherence ${avgAdherence.toFixed(1)}, mean output ${avgOutput.toFixed(1)}`,
+      stddev,
     });
   }
 

--- a/src/scorer/aggregator.ts
+++ b/src/scorer/aggregator.ts
@@ -7,12 +7,18 @@
 import type { TaskResult, CombinedScore, FailureCategory, ScoreStddev } from '../types.js';
 
 /**
+ * Stddev threshold (on the 1-5 scale) above which a task is flagged as "potentially flaky."
+ */
+export const FLAKY_STDDEV_THRESHOLD = 1.0;
+
+/**
  * Compute sample standard deviation (N-1 denominator).
  * Returns 0 when fewer than 2 values are provided.
  */
-export function computeStddev(values: number[], mean: number): number {
+export function computeStddev(values: number[], mean?: number): number {
   if (values.length < 2) return 0;
-  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (values.length - 1);
+  const m = mean ?? values.reduce((sum, v) => sum + v, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + (v - m) ** 2, 0) / (values.length - 1);
   return Math.sqrt(variance);
 }
 

--- a/src/scorer/aggregator.ts
+++ b/src/scorer/aggregator.ts
@@ -14,6 +14,12 @@ export const FLAKY_STDDEV_THRESHOLD = 1.0;
 /**
  * Compute sample standard deviation (N-1 denominator).
  * Returns 0 when fewer than 2 values are provided.
+ *
+ * @param values - Array of numeric values
+ * @param mean - Pre-computed arithmetic mean of `values`. If provided, it must
+ *               be the true mean of the given values; an incorrect value will
+ *               produce an incorrect result. When omitted, the mean is computed
+ *               internally.
  */
 export function computeStddev(values: number[], mean?: number): number {
   if (values.length < 2) return 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,14 @@ export interface CombinedScore {
   weightedScore: number; // 0-1 normalized
   failureCategory: FailureCategory;
   reasoning: string;
+  stddev?: ScoreStddev; // Only populated when N >= 2
+}
+
+export interface ScoreStddev {
+  discovery: number;
+  adherence: number;
+  outputQuality: number;
+  weightedScore: number;
 }
 
 // ============================================
@@ -189,6 +197,7 @@ export interface EvaluationSummary {
   avgWeightedScore: number; // 0-1
   totalDurationMs: number;
   totalCostUsd: number;
+  stddev?: ScoreStddev; // Only populated when N >= 2
 }
 
 export interface FailureBreakdown {


### PR DESCRIPTION
## Summary
- Adds `ScoreStddev` type and `computeStddev()` helper for sample standard deviation (N-1 denominator)
- `aggregateScores()` now computes stddev for discovery, adherence, outputQuality, and weightedScore across runs
- All report outputs (markdown, JSON, GitHub summary, console) show `mean ± stddev` when N >= 2
- Tasks with adherence or output stddev > 1.0 are flagged as potentially flaky
- Single-run evaluations are unaffected — all stddev fields are optional

## Test plan
- [ ] `npm run build` and `npm run typecheck` pass
- [ ] Run multi-run eval (`--runs 3`) and verify stddev appears in markdown summary table, per-task tables, and JSON output
- [ ] Verify high-variance tasks show flaky warning in markdown report
- [ ] Verify GitHub Actions summary includes Variance column for multi-run evals
- [ ] Run single-run eval and verify no stddev fields appear anywhere

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)