### PR TITLE
Track golden checklist items individually in judge scoring

### DIFF
--- a/src/__tests__/github-summary.test.ts
+++ b/src/__tests__/github-summary.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { generateGitHubSummary } from '../report/github-summary.js';
+import type { EvaluationReport } from '../types.js';
+
+function makeReport(overrides: Partial<EvaluationReport> = {}): EvaluationReport {
+  return {
+    skillName: 'test-skill',
+    timestamp: '2026-01-01T00:00:00Z',
+    passed: true,
+    failureReasons: [],
+    summary: {
+      totalTasks: 1,
+      numRuns: 1,
+      discoveryAccuracy: 1,
+      avgAdherence: 5,
+      avgOutputQuality: 5,
+      avgWeightedScore: 1,
+      totalDurationMs: 1000,
+      totalCostUsd: 0.01,
+    },
+    failureBreakdown: [],
+    tasks: [],
+    ...overrides,
+  };
+}
+
+describe('generateGitHubSummary', () => {
+  it('escapes markdown special characters in checklist evidence', () => {
+    const report = makeReport({
+      tasks: [
+        {
+          task: {
+            id: 'task-1',
+            prompt: 'Do something',
+            expectedSkillLoad: 'test-skill',
+            criteria: [],
+            goldenChecklist: ['Check pipes | and _underscores_'],
+          },
+          result: {
+            taskId: 'task-1',
+            prompt: 'Do something',
+            output: 'done',
+            durationMs: 500,
+            numTurns: 1,
+            costUsd: 0.001,
+            skillLoads: ['test-skill'],
+            toolCalls: [],
+            isError: false,
+            errorMessage: '',
+          },
+          score: {
+            taskId: 'task-1',
+            deterministic: null,
+            judge: null,
+            discovery: 1,
+            adherence: 5,
+            outputQuality: 5,
+            weightedScore: 1,
+            failureCategory: 'none',
+            reasoning: 'Good',
+            checklistResults: [
+              { item: 'Has pipes', passed: false, evidence: 'Missing | character in _output_' },
+              { item: 'Has backticks', passed: false, evidence: 'No `code` found' },
+              { item: 'Passing item', passed: true, evidence: 'Looks good' },
+            ],
+          },
+        },
+      ],
+    });
+
+    const summary = generateGitHubSummary(report);
+
+    // Failed items should have escaped evidence
+    expect(summary).toContain('Missing \\| character in \\_output\\_');
+    expect(summary).toContain('No \\`code\\` found');
+    // Passing items should not show evidence
+    expect(summary).not.toContain('Looks good');
+  });
+
+  it('handles checklist items with no evidence', () => {
+    const report = makeReport({
+      tasks: [
+        {
+          task: {
+            id: 'task-1',
+            prompt: 'Do something',
+            expectedSkillLoad: 'test-skill',
+            criteria: [],
+            goldenChecklist: ['Check something'],
+          },
+          result: {
+            taskId: 'task-1',
+            prompt: 'Do something',
+            output: 'done',
+            durationMs: 500,
+            numTurns: 1,
+            costUsd: 0.001,
+            skillLoads: ['test-skill'],
+            toolCalls: [],
+            isError: false,
+            errorMessage: '',
+          },
+          score: {
+            taskId: 'task-1',
+            deterministic: null,
+            judge: null,
+            discovery: 1,
+            adherence: 5,
+            outputQuality: 5,
+            weightedScore: 1,
+            failureCategory: 'none',
+            reasoning: 'Good',
+            checklistResults: [
+              { item: 'No evidence item', passed: false },
+            ],
+          },
+        },
+      ],
+    });
+
+    const summary = generateGitHubSummary(report);
+    expect(summary).toContain('- FAIL: No evidence item');
+    // Should not have a trailing dash for missing evidence
+    expect(summary).not.toContain('— ');
+  });
+});

--- a/src/__tests__/judge.test.ts
+++ b/src/__tests__/judge.test.ts
@@ -205,6 +205,16 @@ describe('parseJudgeResponseJson', () => {
     expect(score.reasoning).toContain('Invalid JSON');
   });
 
+  it('returns error score for single-quoted JSON with valid structure', () => {
+    const response = "{'discovery': 1, 'adherence': 5, 'output_quality': 4, 'failure_category': 'none', 'reasoning': 'Good'}";
+    const score = parseJudgeResponseJson(response, 'task-sq2', defaultWeights);
+
+    expect(score.failureCategory).toBe('agent_error');
+    expect(score.reasoning).toContain('Invalid JSON');
+    expect(score.discovery).toBe(0);
+    expect(score.weightedScore).toBe(0);
+  });
+
   it('computes weighted score correctly', () => {
     const response = JSON.stringify({
       discovery: 1,
@@ -220,6 +230,53 @@ describe('parseJudgeResponseJson', () => {
     // output=5: 0.3*((5-1)/4) = 0.3*1 = 0.3
     // total = 1.0
     expect(score.weightedScore).toBeCloseTo(1.0);
+  });
+
+  it('falls back to agent_error for unknown failure category', () => {
+    const response = JSON.stringify({
+      discovery: 1,
+      adherence: 3,
+      output_quality: 3,
+      failure_category: 'hallucinated_category',
+      reasoning: 'Some issue',
+    });
+    const score = parseJudgeResponseJson(response, 'task-fc', defaultWeights);
+
+    expect(score.failureCategory).toBe('agent_error');
+  });
+
+  it('accepts all valid failure categories', () => {
+    const categories = [
+      'discovery_failure',
+      'false_positive',
+      'instruction_ambiguity',
+      'missing_guidance',
+      'agent_error',
+      'none',
+    ];
+    for (const cat of categories) {
+      const response = JSON.stringify({
+        discovery: 1,
+        adherence: 5,
+        output_quality: 5,
+        failure_category: cat,
+        reasoning: 'test',
+      });
+      const score = parseJudgeResponseJson(response, `task-${cat}`, defaultWeights);
+      expect(score.failureCategory).toBe(cat);
+    }
+  });
+
+  it('falls back to agent_error when failure_category is missing', () => {
+    const response = JSON.stringify({
+      discovery: 1,
+      adherence: 3,
+      output_quality: 3,
+      reasoning: 'No category provided',
+    });
+    const score = parseJudgeResponseJson(response, 'task-nocat', defaultWeights);
+
+    expect(score.failureCategory).toBe('agent_error');
   });
 
   it('handles response wrapped in markdown code block', () => {

--- a/src/__tests__/judge.test.ts
+++ b/src/__tests__/judge.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { extractJsonObject } from '../scorer/judge.js';
+
+describe('extractJsonObject', () => {
+  it('extracts a simple JSON object', () => {
+    const result = extractJsonObject('{"a": 1}');
+    expect(result).toBe('{"a": 1}');
+  });
+
+  it('extracts JSON from surrounding text', () => {
+    const result = extractJsonObject('Here is the result: {"score": 5} done.');
+    expect(result).toBe('{"score": 5}');
+  });
+
+  it('extracts JSON from a code block', () => {
+    const result = extractJsonObject('```json\n{"a": {"b": 1}}\n```');
+    expect(result).toBe('{"a": {"b": 1}}');
+  });
+
+  it('handles nested objects', () => {
+    const input = '{"outer": {"inner": {"deep": true}}, "flat": 1}';
+    expect(extractJsonObject(input)).toBe(input);
+  });
+
+  it('handles braces inside strings', () => {
+    const input = '{"msg": "use { and }"}';
+    expect(extractJsonObject(input)).toBe(input);
+  });
+
+  it('handles escaped quotes inside strings', () => {
+    const input = '{"msg": "he said \\"hello\\""}';
+    expect(extractJsonObject(input)).toBe(input);
+  });
+
+  it('handles checklist_results with nested array of objects', () => {
+    const input = JSON.stringify({
+      discovery: 1,
+      adherence: 5,
+      output_quality: 4,
+      failure_category: 'none',
+      reasoning: 'Good job',
+      checklist_results: [
+        { item: 'Did X', passed: true, evidence: 'Found X in output' },
+        { item: 'Did Y', passed: false, evidence: 'Y was missing' },
+      ],
+    });
+    const result = extractJsonObject(input);
+    expect(result).toBe(input);
+    expect(JSON.parse(result!).checklist_results).toHaveLength(2);
+  });
+
+  it('extracts JSON with checklist from markdown code block', () => {
+    const wrapped = '```json\n' + JSON.stringify({
+      discovery: 1,
+      checklist_results: [{ item: 'test', passed: true, evidence: 'ok' }],
+    }) + '\n```';
+    const result = extractJsonObject(wrapped);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.checklist_results[0].item).toBe('test');
+  });
+
+  it('returns null when no JSON present', () => {
+    expect(extractJsonObject('no json here')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractJsonObject('')).toBeNull();
+  });
+
+  it('returns null for unbalanced braces', () => {
+    expect(extractJsonObject('{"a": 1')).toBeNull();
+  });
+
+  it('handles strings with escaped backslashes', () => {
+    const input = '{"path": "C:\\\\Users\\\\test"}';
+    expect(extractJsonObject(input)).toBe(input);
+  });
+});

--- a/src/__tests__/judge.test.ts
+++ b/src/__tests__/judge.test.ts
@@ -198,6 +198,13 @@ describe('parseJudgeResponseJson', () => {
     expect(score.reasoning).toContain('Invalid JSON');
   });
 
+  it('returns error score for single-quoted JSON', () => {
+    const score = parseJudgeResponseJson("{'discovery': 1}", 'task-sq', defaultWeights);
+
+    expect(score.failureCategory).toBe('agent_error');
+    expect(score.reasoning).toContain('Invalid JSON');
+  });
+
   it('computes weighted score correctly', () => {
     const response = JSON.stringify({
       discovery: 1,

--- a/src/__tests__/judge.test.ts
+++ b/src/__tests__/judge.test.ts
@@ -106,12 +106,12 @@ describe('parseJudgeResponseJson', () => {
     expect(score.failureCategory).toBe('none');
     expect(score.reasoning).toBe('Agent performed well');
     expect(score.checklistResults).toHaveLength(2);
-    expect(score.checklistResults![0]).toEqual({
+    expect(score.checklistResults[0]).toEqual({
       item: 'Used correct format',
       passed: true,
       evidence: 'Output matches expected format',
     });
-    expect(score.checklistResults![1]).toEqual({
+    expect(score.checklistResults[1]).toEqual({
       item: 'Included header',
       passed: false,
       evidence: 'Header was missing',
@@ -152,9 +152,9 @@ describe('parseJudgeResponseJson', () => {
     const score = parseJudgeResponseJson(response, 'task-3', defaultWeights);
 
     expect(score.checklistResults).toHaveLength(2);
-    expect(score.checklistResults![0].item).toBe('Valid item');
-    expect(score.checklistResults![1].item).toBe('Also valid');
-    expect(score.checklistResults![1].passed).toBe(false);
+    expect(score.checklistResults[0].item).toBe('Valid item');
+    expect(score.checklistResults[1].item).toBe('Also valid');
+    expect(score.checklistResults[1].passed).toBe(false);
   });
 
   it('coerces non-standard types in checklist results', () => {
@@ -172,12 +172,12 @@ describe('parseJudgeResponseJson', () => {
     const score = parseJudgeResponseJson(response, 'task-4', defaultWeights);
 
     expect(score.checklistResults).toHaveLength(2);
-    expect(score.checklistResults![0].item).toBe('123');
-    expect(score.checklistResults![0].passed).toBe(true);
-    expect(score.checklistResults![0].evidence).toBe('coerced');
-    expect(score.checklistResults![1].item).toBe('text');
-    expect(score.checklistResults![1].passed).toBe(false);
-    expect(score.checklistResults![1].evidence).toBeUndefined();
+    expect(score.checklistResults[0].item).toBe('123');
+    expect(score.checklistResults[0].passed).toBe(true);
+    expect(score.checklistResults[0].evidence).toBe('coerced');
+    expect(score.checklistResults[1].item).toBe('text');
+    expect(score.checklistResults[1].passed).toBe(false);
+    expect(score.checklistResults[1].evidence).toBeUndefined();
   });
 
   it('returns error score for unparseable response', () => {

--- a/src/__tests__/judge.test.ts
+++ b/src/__tests__/judge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractJsonObject } from '../scorer/judge.js';
+import { extractJsonObject, parseJudgeResponseJson } from '../scorer/judge.js';
 
 describe('extractJsonObject', () => {
   it('extracts a simple JSON object', () => {
@@ -75,5 +75,159 @@ describe('extractJsonObject', () => {
   it('handles strings with escaped backslashes', () => {
     const input = '{"path": "C:\\\\Users\\\\test"}';
     expect(extractJsonObject(input)).toBe(input);
+  });
+});
+
+describe('parseJudgeResponseJson', () => {
+  const defaultWeights = new Map([
+    ['discovery', 0.3],
+    ['adherence', 0.4],
+    ['output', 0.3],
+  ]);
+
+  it('parses a complete judge response with checklist results', () => {
+    const response = JSON.stringify({
+      discovery: 1,
+      adherence: 5,
+      output_quality: 4,
+      failure_category: 'none',
+      reasoning: 'Agent performed well',
+      checklist_results: [
+        { item: 'Used correct format', passed: true, evidence: 'Output matches expected format' },
+        { item: 'Included header', passed: false, evidence: 'Header was missing' },
+      ],
+    });
+    const score = parseJudgeResponseJson(response, 'task-1', defaultWeights);
+
+    expect(score.taskId).toBe('task-1');
+    expect(score.discovery).toBe(1);
+    expect(score.adherence).toBe(5);
+    expect(score.outputQuality).toBe(4);
+    expect(score.failureCategory).toBe('none');
+    expect(score.reasoning).toBe('Agent performed well');
+    expect(score.checklistResults).toHaveLength(2);
+    expect(score.checklistResults![0]).toEqual({
+      item: 'Used correct format',
+      passed: true,
+      evidence: 'Output matches expected format',
+    });
+    expect(score.checklistResults![1]).toEqual({
+      item: 'Included header',
+      passed: false,
+      evidence: 'Header was missing',
+    });
+  });
+
+  it('parses response without checklist results', () => {
+    const response = JSON.stringify({
+      discovery: 1,
+      adherence: 4,
+      output_quality: 3,
+      failure_category: 'none',
+      reasoning: 'Decent output',
+    });
+    const score = parseJudgeResponseJson(response, 'task-2', defaultWeights);
+
+    expect(score.checklistResults).toEqual([]);
+    expect(score.adherence).toBe(4);
+    expect(score.outputQuality).toBe(3);
+  });
+
+  it('filters out malformed checklist entries', () => {
+    const response = JSON.stringify({
+      discovery: 1,
+      adherence: 5,
+      output_quality: 5,
+      failure_category: 'none',
+      reasoning: 'Great',
+      checklist_results: [
+        { item: 'Valid item', passed: true, evidence: 'Yes' },
+        { wrong_field: 'no item key' },
+        'not an object',
+        null,
+        { item: 'Missing passed field' },
+        { item: 'Also valid', passed: false },
+      ],
+    });
+    const score = parseJudgeResponseJson(response, 'task-3', defaultWeights);
+
+    expect(score.checklistResults).toHaveLength(2);
+    expect(score.checklistResults![0].item).toBe('Valid item');
+    expect(score.checklistResults![1].item).toBe('Also valid');
+    expect(score.checklistResults![1].passed).toBe(false);
+  });
+
+  it('coerces non-standard types in checklist results', () => {
+    const response = JSON.stringify({
+      discovery: 1,
+      adherence: 5,
+      output_quality: 5,
+      failure_category: 'none',
+      reasoning: 'Ok',
+      checklist_results: [
+        { item: 123, passed: 1, evidence: 'coerced' },
+        { item: 'text', passed: 0 },
+      ],
+    });
+    const score = parseJudgeResponseJson(response, 'task-4', defaultWeights);
+
+    expect(score.checklistResults).toHaveLength(2);
+    expect(score.checklistResults![0].item).toBe('123');
+    expect(score.checklistResults![0].passed).toBe(true);
+    expect(score.checklistResults![0].evidence).toBe('coerced');
+    expect(score.checklistResults![1].item).toBe('text');
+    expect(score.checklistResults![1].passed).toBe(false);
+    expect(score.checklistResults![1].evidence).toBeUndefined();
+  });
+
+  it('returns error score for unparseable response', () => {
+    const score = parseJudgeResponseJson('no json here', 'task-5', defaultWeights);
+
+    expect(score.discovery).toBe(0);
+    expect(score.adherence).toBe(1);
+    expect(score.outputQuality).toBe(1);
+    expect(score.weightedScore).toBe(0);
+    expect(score.failureCategory).toBe('agent_error');
+    expect(score.reasoning).toContain('Failed to parse');
+  });
+
+  it('returns error score for invalid JSON', () => {
+    const score = parseJudgeResponseJson('{not valid json}', 'task-6', defaultWeights);
+
+    expect(score.failureCategory).toBe('agent_error');
+    expect(score.reasoning).toContain('Invalid JSON');
+  });
+
+  it('computes weighted score correctly', () => {
+    const response = JSON.stringify({
+      discovery: 1,
+      adherence: 5,
+      output_quality: 5,
+      failure_category: 'none',
+      reasoning: 'Perfect',
+    });
+    const score = parseJudgeResponseJson(response, 'task-7', defaultWeights);
+
+    // discovery=1: 0.3*1 = 0.3
+    // adherence=5: 0.4*((5-1)/4) = 0.4*1 = 0.4
+    // output=5: 0.3*((5-1)/4) = 0.3*1 = 0.3
+    // total = 1.0
+    expect(score.weightedScore).toBeCloseTo(1.0);
+  });
+
+  it('handles response wrapped in markdown code block', () => {
+    const json = JSON.stringify({
+      discovery: 0,
+      adherence: 2,
+      output_quality: 1,
+      failure_category: 'discovery_failure',
+      reasoning: 'Skill not loaded',
+    });
+    const response = `Here is my evaluation:\n\`\`\`json\n${json}\n\`\`\`\nThat concludes the review.`;
+    const score = parseJudgeResponseJson(response, 'task-8', defaultWeights);
+
+    expect(score.discovery).toBe(0);
+    expect(score.adherence).toBe(2);
+    expect(score.failureCategory).toBe('discovery_failure');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ToolCallRecord,
   TaskResult,
   FailureCategory,
+  ChecklistItemResult,
   JudgeScore,
   JudgeOptions,
   CombinedScore,

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -89,7 +89,8 @@ export function generateGitHubSummary(report: EvaluationReport): string {
       for (const cr of results) {
         const safeItem = cr.item.replace(/\|/g, '\\|');
         const line = `- ${cr.passed ? 'PASS' : 'FAIL'}: ${safeItem}`;
-        lines.push(!cr.passed && cr.evidence?.trim() ? `${line} — ${cr.evidence.trim()}` : line);
+        const safeEvidence = cr.evidence?.trim().replace(/[|_*`]/g, '\\$&');
+        lines.push(!cr.passed && safeEvidence ? `${line} — ${safeEvidence}` : line);
       }
       lines.push('');
     }

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -78,12 +78,12 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   }
   // Per-task checklist summaries
   const tasksWithChecklist = tasks.filter(
-    (t) => t.score.checklistResults.length > 0
+    (t) => (t.score.checklistResults ?? []).length > 0
   );
   if (tasksWithChecklist.length > 0) {
     lines.push('');
     for (const t of tasksWithChecklist) {
-      const results = t.score.checklistResults;
+      const results = t.score.checklistResults ?? [];
       const passed = results.filter((cr) => cr.passed).length;
       lines.push(`**${t.task.id} checklist:** ${passed}/${results.length}`);
       for (const cr of results) {

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -78,12 +78,12 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   }
   // Per-task checklist summaries
   const tasksWithChecklist = tasks.filter(
-    (t) => t.score.checklistResults && t.score.checklistResults.length > 0
+    (t) => t.score.checklistResults.length > 0
   );
   if (tasksWithChecklist.length > 0) {
     lines.push('');
     for (const t of tasksWithChecklist) {
-      const results = t.score.checklistResults!;
+      const results = t.score.checklistResults;
       const passed = results.filter((cr) => cr.passed).length;
       lines.push(`**${t.task.id} checklist:** ${passed}/${results.length}`);
       for (const cr of results) {

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -88,7 +88,8 @@ export function generateGitHubSummary(report: EvaluationReport): string {
       lines.push(`**${t.task.id} checklist:** ${passed}/${results.length}`);
       for (const cr of results) {
         const safeItem = cr.item.replace(/\|/g, '\\|');
-        lines.push(`- ${cr.passed ? 'PASS' : 'FAIL'}: ${safeItem}`);
+        const line = `- ${cr.passed ? 'PASS' : 'FAIL'}: ${safeItem}`;
+        lines.push(!cr.passed && cr.evidence?.trim() ? `${line} — ${cr.evidence.trim()}` : line);
       }
       lines.push('');
     }

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -76,6 +76,23 @@ export function generateGitHubSummary(report: EvaluationReport): string {
       lines.push(`| ${t.task.id} | ${(s.discovery * 100).toFixed(0)}% | ${s.adherence.toFixed(1)}/5 | ${s.outputQuality.toFixed(1)}/5 | ${s.weightedScore.toFixed(2)} | ${status} |`);
     }
   }
+  // Per-task checklist summaries
+  const tasksWithChecklist = tasks.filter(
+    (t) => t.score.checklistResults.length > 0
+  );
+  if (tasksWithChecklist.length > 0) {
+    lines.push('');
+    for (const t of tasksWithChecklist) {
+      const results = t.score.checklistResults;
+      const passed = results.filter((cr) => cr.passed).length;
+      lines.push(`**${t.task.id} checklist:** ${passed}/${results.length}`);
+      for (const cr of results) {
+        lines.push(`- ${cr.passed ? 'PASS' : 'FAIL'}: ${cr.item}`);
+      }
+      lines.push('');
+    }
+  }
+
   lines.push('');
   lines.push('</details>');
   lines.push('');

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -87,7 +87,8 @@ export function generateGitHubSummary(report: EvaluationReport): string {
       const passed = results.filter((cr) => cr.passed).length;
       lines.push(`**${t.task.id} checklist:** ${passed}/${results.length}`);
       for (const cr of results) {
-        lines.push(`- ${cr.passed ? 'PASS' : 'FAIL'}: ${cr.item}`);
+        const safeItem = cr.item.replace(/\|/g, '\\|');
+        lines.push(`- ${cr.passed ? 'PASS' : 'FAIL'}: ${safeItem}`);
       }
       lines.push('');
     }

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -78,12 +78,12 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   }
   // Per-task checklist summaries
   const tasksWithChecklist = tasks.filter(
-    (t) => t.score.checklistResults.length > 0
+    (t) => t.score.checklistResults && t.score.checklistResults.length > 0
   );
   if (tasksWithChecklist.length > 0) {
     lines.push('');
     for (const t of tasksWithChecklist) {
-      const results = t.score.checklistResults;
+      const results = t.score.checklistResults!;
       const passed = results.filter((cr) => cr.passed).length;
       lines.push(`**${t.task.id} checklist:** ${passed}/${results.length}`);
       for (const cr of results) {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -127,11 +127,12 @@ ${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stdd
     }
 
     // Show checklist results if available
-    if (score.checklistResults && score.checklistResults.length > 0) {
+    if (score.checklistResults.length > 0) {
       const checklistPassed = score.checklistResults.filter((cr) => cr.passed).length;
       report += `\n**Checklist:** ${checklistPassed}/${score.checklistResults.length} passed\n\n`;
       for (const cr of score.checklistResults) {
-        report += `- ${cr.passed ? 'PASS' : 'FAIL'}: **${cr.item}**\n`;
+        const safeItem = cr.item.replace(/[|_*`]/g, '\\$&');
+        report += `- ${cr.passed ? 'PASS' : 'FAIL'}: **${safeItem}**\n`;
         if (cr.evidence?.trim()) {
           const safeEvidence = cr.evidence.trim().replace(/[|_*`]/g, '\\$&');
           report += `  - _${safeEvidence}_\n`;

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -127,7 +127,7 @@ ${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stdd
     }
 
     // Show checklist results if available
-    if (score.checklistResults.length > 0) {
+    if (score.checklistResults && score.checklistResults.length > 0) {
       const passed = score.checklistResults.filter((cr) => cr.passed).length;
       report += `\n**Checklist:** ${passed}/${score.checklistResults.length} passed\n\n`;
       for (const cr of score.checklistResults) {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -127,10 +127,10 @@ ${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stdd
     }
 
     // Show checklist results if available
-    if (score.checklistResults.length > 0) {
-      const checklistPassed = score.checklistResults.filter((cr) => cr.passed).length;
-      report += `\n**Checklist:** ${checklistPassed}/${score.checklistResults.length} passed\n\n`;
-      for (const cr of score.checklistResults) {
+    if ((score.checklistResults ?? []).length > 0) {
+      const checklistPassed = (score.checklistResults ?? []).filter((cr) => cr.passed).length;
+      report += `\n**Checklist:** ${checklistPassed}/${(score.checklistResults ?? []).length} passed\n\n`;
+      for (const cr of score.checklistResults ?? []) {
         const safeItem = cr.item.replace(/[|_*`]/g, '\\$&');
         report += `- ${cr.passed ? 'PASS' : 'FAIL'}: **${safeItem}**\n`;
         if (cr.evidence?.trim()) {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -126,6 +126,18 @@ ${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stdd
       }
     }
 
+    // Show checklist results if available
+    if (score.checklistResults.length > 0) {
+      const passed = score.checklistResults.filter((cr) => cr.passed).length;
+      report += `\n**Checklist:** ${passed}/${score.checklistResults.length} passed\n\n`;
+      for (const cr of score.checklistResults) {
+        report += `- ${cr.passed ? 'PASS' : 'FAIL'}: **${cr.item}**\n`;
+        if (cr.evidence) {
+          report += `  - _${cr.evidence}_\n`;
+        }
+      }
+    }
+
     report += `\n**Reasoning:** ${score.reasoning || 'No reasoning provided'}
 
 <details>

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -132,8 +132,8 @@ ${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stdd
       report += `\n**Checklist:** ${passed}/${score.checklistResults.length} passed\n\n`;
       for (const cr of score.checklistResults) {
         report += `- ${cr.passed ? 'PASS' : 'FAIL'}: **${cr.item}**\n`;
-        if (cr.evidence) {
-          report += `  - _${cr.evidence}_\n`;
+        if (cr.evidence?.trim()) {
+          report += `  - _${cr.evidence.trim()}_\n`;
         }
       }
     }

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -128,12 +128,13 @@ ${score.stddev && (score.stddev.adherence > FLAKY_STDDEV_THRESHOLD || score.stdd
 
     // Show checklist results if available
     if (score.checklistResults && score.checklistResults.length > 0) {
-      const passed = score.checklistResults.filter((cr) => cr.passed).length;
-      report += `\n**Checklist:** ${passed}/${score.checklistResults.length} passed\n\n`;
+      const checklistPassed = score.checklistResults.filter((cr) => cr.passed).length;
+      report += `\n**Checklist:** ${checklistPassed}/${score.checklistResults.length} passed\n\n`;
       for (const cr of score.checklistResults) {
         report += `- ${cr.passed ? 'PASS' : 'FAIL'}: **${cr.item}**\n`;
         if (cr.evidence?.trim()) {
-          report += `  - _${cr.evidence.trim()}_\n`;
+          const safeEvidence = cr.evidence.trim().replace(/[|_*`]/g, '\\$&');
+          report += `  - _${safeEvidence}_\n`;
         }
       }
     }

--- a/src/scorer/aggregator.ts
+++ b/src/scorer/aggregator.ts
@@ -124,6 +124,17 @@ export function aggregateScores(allScores: CombinedScore[][]): CombinedScore[] {
 
     const discoveryCount = scores.filter((s) => s.discovery >= 1).length;
 
+    // Find representative run's checklist results (closest to mean weighted score)
+    let repIdx = 0;
+    let minDist = Infinity;
+    for (let r = 0; r < numRuns; r++) {
+      const dist = Math.abs(scores[r].weightedScore - avgWeighted);
+      if (dist < minDist) {
+        minDist = dist;
+        repIdx = r;
+      }
+    }
+
     aggregated.push({
       taskId: scores[0].taskId,
       deterministic: null,
@@ -134,6 +145,7 @@ export function aggregateScores(allScores: CombinedScore[][]): CombinedScore[] {
       weightedScore: avgWeighted,
       failureCategory: modeCategory,
       reasoning: `Aggregated over ${numRuns} runs: discovery ${discoveryCount}/${numRuns}, mean adherence ${avgAdherence.toFixed(1)}, mean output ${avgOutput.toFixed(1)}`,
+      checklistResults: scores[repIdx].checklistResults,
       stddev,
     });
   }

--- a/src/scorer/aggregator.ts
+++ b/src/scorer/aggregator.ts
@@ -29,6 +29,23 @@ export function computeStddev(values: number[], mean?: number): number {
 }
 
 /**
+ * Find the index of the run closest to the mean weighted score.
+ */
+function findRepresentativeIndex(scores: CombinedScore[]): number {
+  const mean = scores.reduce((sum, s) => sum + s.weightedScore, 0) / scores.length;
+  let repIdx = 0;
+  let minDist = Infinity;
+  for (let r = 0; r < scores.length; r++) {
+    const dist = Math.abs(scores[r].weightedScore - mean);
+    if (dist < minDist) {
+      minDist = dist;
+      repIdx = r;
+    }
+  }
+  return repIdx;
+}
+
+/**
  * Aggregate multiple runs of TaskResult[] into a single TaskResult per task.
  *
  * For each task position, picks the "representative" run (closest to median
@@ -49,18 +66,7 @@ export function aggregateResults(
     const runs = allResults.map((r) => r[t]);
     const scores = allScores.map((s) => s[t]);
 
-    // Find the representative run (closest to mean weighted score)
-    const meanWeighted = scores.reduce((sum, s) => sum + s.weightedScore, 0) / numRuns;
-    let repIdx = 0;
-    let minDist = Infinity;
-    for (let r = 0; r < numRuns; r++) {
-      const dist = Math.abs(scores[r].weightedScore - meanWeighted);
-      if (dist < minDist) {
-        minDist = dist;
-        repIdx = r;
-      }
-    }
-
+    const repIdx = findRepresentativeIndex(scores);
     const rep = runs[repIdx];
     aggregated.push({
       taskId: rep.taskId,
@@ -124,16 +130,7 @@ export function aggregateScores(allScores: CombinedScore[][]): CombinedScore[] {
 
     const discoveryCount = scores.filter((s) => s.discovery >= 1).length;
 
-    // Find representative run's checklist results (closest to mean weighted score)
-    let repIdx = 0;
-    let minDist = Infinity;
-    for (let r = 0; r < numRuns; r++) {
-      const dist = Math.abs(scores[r].weightedScore - avgWeighted);
-      if (dist < minDist) {
-        minDist = dist;
-        repIdx = r;
-      }
-    }
+    const repIdx = findRepresentativeIndex(scores);
 
     aggregated.push({
       taskId: scores[0].taskId,

--- a/src/scorer/aggregator.ts
+++ b/src/scorer/aggregator.ts
@@ -142,7 +142,7 @@ export function aggregateScores(allScores: CombinedScore[][]): CombinedScore[] {
       weightedScore: avgWeighted,
       failureCategory: modeCategory,
       reasoning: `Aggregated over ${numRuns} runs: discovery ${discoveryCount}/${numRuns}, mean adherence ${avgAdherence.toFixed(1)}, mean output ${avgOutput.toFixed(1)}`,
-      checklistResults: scores[repIdx].checklistResults,
+      checklistResults: scores[repIdx].checklistResults ?? [],
       stddev,
     });
   }

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -199,6 +199,7 @@ function createErrorScore(taskId: string, reason: string): JudgeScore {
     weightedScore: 0,
     failureCategory: 'agent_error',
     reasoning: reason,
+    checklistResults: [],
   };
 }
 

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -86,6 +86,49 @@ Respond with a JSON object:
 `;
 
 /**
+ * Extract the first complete JSON object from text, handling nested braces.
+ */
+export function extractJsonObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (ch === '\\' && inString) {
+      escape = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return text.substring(start, i + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
  * LLM-as-judge for scoring skill evaluation results.
  */
 export class SkillJudge {
@@ -147,49 +190,6 @@ export class SkillJudge {
   }
 
   /**
-   * Extract the first complete JSON object from text, handling nested braces.
-   */
-  private extractJsonObject(text: string): string | null {
-    const start = text.indexOf('{');
-    if (start === -1) return null;
-
-    let depth = 0;
-    let inString = false;
-    let escape = false;
-
-    for (let i = start; i < text.length; i++) {
-      const ch = text[i];
-
-      if (escape) {
-        escape = false;
-        continue;
-      }
-
-      if (ch === '\\' && inString) {
-        escape = true;
-        continue;
-      }
-
-      if (ch === '"') {
-        inString = !inString;
-        continue;
-      }
-
-      if (inString) continue;
-
-      if (ch === '{') depth++;
-      else if (ch === '}') {
-        depth--;
-        if (depth === 0) {
-          return text.substring(start, i + 1);
-        }
-      }
-    }
-
-    return null;
-  }
-
-  /**
    * Parse the judge's JSON response into a JudgeScore.
    */
   private parseJudgeResponse(
@@ -197,7 +197,7 @@ export class SkillJudge {
     taskId: string,
     weights: Map<string, number>
   ): JudgeScore {
-    const jsonStr = this.extractJsonObject(response);
+    const jsonStr = extractJsonObject(response);
     if (!jsonStr) {
       return this.createErrorScore(taskId, 'Failed to parse judge response');
     }

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -181,13 +181,26 @@ export function parseJudgeResponseJson(
       adherence,
       outputQuality,
       weightedScore,
-      failureCategory: (data.failure_category || 'none') as FailureCategory,
+      failureCategory: isValidFailureCategory(data.failure_category) ? data.failure_category : 'agent_error',
       reasoning: data.reasoning || '',
       checklistResults,
     };
   } catch {
     return createErrorScore(taskId, 'Invalid JSON in judge response');
   }
+}
+
+const VALID_FAILURE_CATEGORIES: readonly FailureCategory[] = [
+  'discovery_failure',
+  'false_positive',
+  'instruction_ambiguity',
+  'missing_guidance',
+  'agent_error',
+  'none',
+];
+
+function isValidFailureCategory(value: unknown): value is FailureCategory {
+  return typeof value === 'string' && VALID_FAILURE_CATEGORIES.includes(value as FailureCategory);
 }
 
 function createErrorScore(taskId: string, reason: string): JudgeScore {

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -14,6 +14,7 @@ import type {
   JudgeScore,
   JudgeOptions,
   FailureCategory,
+  ChecklistItemResult,
 } from '../types.js';
 import {
   isAssistantMessage,
@@ -71,7 +72,7 @@ Score the agent's performance on three dimensions:
    - "missing_guidance": Skill didn't cover a needed case
    - "agent_error": Agent made a mistake despite clear guidance
    - "none": No significant failure
-
+{checklistScoringInstructions}
 Respond with a JSON object:
 \`\`\`json
 {
@@ -79,7 +80,7 @@ Respond with a JSON object:
   "adherence": <1-5>,
   "output_quality": <1-5>,
   "failure_category": "<category or none>",
-  "reasoning": "<brief explanation of scores>"
+  "reasoning": "<brief explanation of scores>"{checklistJsonField}
 }
 \`\`\`
 `;
@@ -118,13 +119,74 @@ export class SkillJudge {
       ? result.skillLoads.join(', ')
       : 'None';
 
+    const hasChecklist = task.goldenChecklist.length > 0;
+    const checklistScoringInstructions = hasChecklist
+      ? `
+5. **Checklist Results** (per-item pass/fail):
+   For each item in the golden checklist above, determine whether the agent's output satisfies it.
+   - Require concrete evidence for a PASS — do not give the benefit of the doubt.
+   - Return an array of objects, one per checklist item, each with "item" (the checklist text), "passed" (true/false), and "evidence" (brief explanation).
+`
+      : '';
+    const checklistJsonField = hasChecklist
+      ? `,
+  "checklist_results": [
+    {"item": "<checklist item text>", "passed": true, "evidence": "<brief explanation>"}
+  ]`
+      : '';
+
     return JUDGE_PROMPT_TEMPLATE
       .replace('{prompt}', task.prompt)
       .replace(/{expectedSkill}/g, task.expectedSkillLoad)
       .replace('{criteriaText}', criteriaText)
       .replace('{checklistText}', checklistText)
+      .replace('{checklistScoringInstructions}', checklistScoringInstructions)
+      .replace('{checklistJsonField}', checklistJsonField)
       .replace('{skillLoads}', skillLoads)
       .replace('{output}', result.output.slice(0, this.options.outputTruncation) || '(no output)');
+  }
+
+  /**
+   * Extract the first complete JSON object from text, handling nested braces.
+   */
+  private extractJsonObject(text: string): string | null {
+    const start = text.indexOf('{');
+    if (start === -1) return null;
+
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+
+    for (let i = start; i < text.length; i++) {
+      const ch = text[i];
+
+      if (escape) {
+        escape = false;
+        continue;
+      }
+
+      if (ch === '\\' && inString) {
+        escape = true;
+        continue;
+      }
+
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+
+      if (inString) continue;
+
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          return text.substring(start, i + 1);
+        }
+      }
+    }
+
+    return null;
   }
 
   /**
@@ -135,13 +197,13 @@ export class SkillJudge {
     taskId: string,
     weights: Map<string, number>
   ): JudgeScore {
-    const jsonMatch = response.match(/\{[\s\S]*?\}/);
-    if (!jsonMatch) {
+    const jsonStr = this.extractJsonObject(response);
+    if (!jsonStr) {
       return this.createErrorScore(taskId, 'Failed to parse judge response');
     }
 
     try {
-      const data = JSON.parse(jsonMatch[0]);
+      const data = JSON.parse(jsonStr);
 
       const discovery = Number(data.discovery) || 0;
       const adherence = Number(data.adherence) || 1;
@@ -155,6 +217,23 @@ export class SkillJudge {
         (weights.get('adherence') ?? 0.4) * adherenceNorm +
         (weights.get('output') ?? 0.3) * outputNorm;
 
+      // Parse checklist results
+      const checklistResults: ChecklistItemResult[] = Array.isArray(data.checklist_results)
+        ? data.checklist_results
+            .filter(
+              (cr: unknown) =>
+                typeof cr === 'object' &&
+                cr !== null &&
+                'item' in (cr as Record<string, unknown>) &&
+                'passed' in (cr as Record<string, unknown>)
+            )
+            .map((cr: { item: string; passed: boolean; evidence?: string }) => ({
+              item: String(cr.item),
+              passed: Boolean(cr.passed),
+              evidence: String(cr.evidence || ''),
+            }))
+        : [];
+
       return {
         taskId,
         discovery,
@@ -163,6 +242,7 @@ export class SkillJudge {
         weightedScore,
         failureCategory: (data.failure_category || 'none') as FailureCategory,
         reasoning: data.reasoning || '',
+        checklistResults,
       };
     } catch {
       return this.createErrorScore(taskId, 'Invalid JSON in judge response');
@@ -178,6 +258,7 @@ export class SkillJudge {
       weightedScore: 0,
       failureCategory: 'agent_error',
       reasoning: reason,
+      checklistResults: [],
     };
   }
 
@@ -194,6 +275,7 @@ export class SkillJudge {
         weightedScore: 0,
         failureCategory: 'agent_error',
         reasoning: `Task failed with error: ${result.errorMessage}`,
+        checklistResults: [],
       };
     }
 
@@ -243,6 +325,7 @@ export class SkillJudge {
         weightedScore: 0.5,
         failureCategory: discovery === 0 ? 'discovery_failure' : 'none',
         reasoning: `Heuristic scoring (judge error: ${error instanceof Error ? error.message : 'unknown'})`,
+        checklistResults: [],
       };
     }
   }

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -129,6 +129,80 @@ export function extractJsonObject(text: string): string | null {
 }
 
 /**
+ * Parse a raw judge response string into a JudgeScore.
+ *
+ * Exported for testing. Extracts JSON, parses scores and checklist results.
+ */
+export function parseJudgeResponseJson(
+  response: string,
+  taskId: string,
+  weights: Map<string, number>
+): JudgeScore {
+  const jsonStr = extractJsonObject(response);
+  if (!jsonStr) {
+    return createErrorScore(taskId, 'Failed to parse judge response');
+  }
+
+  try {
+    const data = JSON.parse(jsonStr);
+
+    const discovery = Number(data.discovery) || 0;
+    const adherence = Number(data.adherence) || 1;
+    const outputQuality = Number(data.output_quality) || 1;
+
+    const adherenceNorm = (adherence - 1) / 4;
+    const outputNorm = (outputQuality - 1) / 4;
+
+    const weightedScore =
+      (weights.get('discovery') ?? 0.3) * discovery +
+      (weights.get('adherence') ?? 0.4) * adherenceNorm +
+      (weights.get('output') ?? 0.3) * outputNorm;
+
+    // Parse checklist results
+    const checklistResults: ChecklistItemResult[] = Array.isArray(data.checklist_results)
+      ? data.checklist_results
+          .filter(
+            (cr: unknown) =>
+              typeof cr === 'object' &&
+              cr !== null &&
+              'item' in (cr as Record<string, unknown>) &&
+              'passed' in (cr as Record<string, unknown>)
+          )
+          .map((cr: { item: string; passed: boolean; evidence?: string }) => ({
+            item: String(cr.item),
+            passed: Boolean(cr.passed),
+            ...(cr.evidence ? { evidence: String(cr.evidence) } : {}),
+          }))
+      : [];
+
+    return {
+      taskId,
+      discovery,
+      adherence,
+      outputQuality,
+      weightedScore,
+      failureCategory: (data.failure_category || 'none') as FailureCategory,
+      reasoning: data.reasoning || '',
+      checklistResults,
+    };
+  } catch {
+    return createErrorScore(taskId, 'Invalid JSON in judge response');
+  }
+}
+
+function createErrorScore(taskId: string, reason: string): JudgeScore {
+  return {
+    taskId,
+    discovery: 0,
+    adherence: 1,
+    outputQuality: 1,
+    weightedScore: 0,
+    failureCategory: 'agent_error',
+    reasoning: reason,
+  };
+}
+
+/**
  * LLM-as-judge for scoring skill evaluation results.
  */
 export class SkillJudge {
@@ -190,79 +264,6 @@ export class SkillJudge {
   }
 
   /**
-   * Parse the judge's JSON response into a JudgeScore.
-   */
-  private parseJudgeResponse(
-    response: string,
-    taskId: string,
-    weights: Map<string, number>
-  ): JudgeScore {
-    const jsonStr = extractJsonObject(response);
-    if (!jsonStr) {
-      return this.createErrorScore(taskId, 'Failed to parse judge response');
-    }
-
-    try {
-      const data = JSON.parse(jsonStr);
-
-      const discovery = Number(data.discovery) || 0;
-      const adherence = Number(data.adherence) || 1;
-      const outputQuality = Number(data.output_quality) || 1;
-
-      const adherenceNorm = (adherence - 1) / 4;
-      const outputNorm = (outputQuality - 1) / 4;
-
-      const weightedScore =
-        (weights.get('discovery') ?? 0.3) * discovery +
-        (weights.get('adherence') ?? 0.4) * adherenceNorm +
-        (weights.get('output') ?? 0.3) * outputNorm;
-
-      // Parse checklist results
-      const checklistResults: ChecklistItemResult[] = Array.isArray(data.checklist_results)
-        ? data.checklist_results
-            .filter(
-              (cr: unknown) =>
-                typeof cr === 'object' &&
-                cr !== null &&
-                'item' in (cr as Record<string, unknown>) &&
-                'passed' in (cr as Record<string, unknown>)
-            )
-            .map((cr: { item: string; passed: boolean; evidence?: string }) => ({
-              item: String(cr.item),
-              passed: Boolean(cr.passed),
-              evidence: String(cr.evidence || ''),
-            }))
-        : [];
-
-      return {
-        taskId,
-        discovery,
-        adherence,
-        outputQuality,
-        weightedScore,
-        failureCategory: (data.failure_category || 'none') as FailureCategory,
-        reasoning: data.reasoning || '',
-        checklistResults,
-      };
-    } catch {
-      return this.createErrorScore(taskId, 'Invalid JSON in judge response');
-    }
-  }
-
-  private createErrorScore(taskId: string, reason: string): JudgeScore {
-    return {
-      taskId,
-      discovery: 0,
-      adherence: 1,
-      outputQuality: 1,
-      weightedScore: 0,
-      failureCategory: 'agent_error',
-      reasoning: reason,
-      checklistResults: [],
-    };
-  }
-
-  /**
    * Score a single evaluation result.
    */
   async judgeResult(task: EvalTask, result: TaskResult): Promise<JudgeScore> {
@@ -313,7 +314,7 @@ export class SkillJudge {
         }
       }
 
-      return this.parseJudgeResponse(responseText, task.id, weights);
+      return parseJudgeResponseJson(responseText, task.id, weights);
     } catch (error) {
       // Fallback: heuristic scoring
       const discovery = result.skillLoads.includes(task.expectedSkillLoad) ? 1 : 0;

--- a/src/scorer/scorer.ts
+++ b/src/scorer/scorer.ts
@@ -134,7 +134,7 @@ function mergeScores(
       weightedScore,
       failureCategory,
       reasoning: reasons.join(' | '),
-      checklistResults: judge.checklistResults,
+      checklistResults: judge.checklistResults ?? [],
     };
   }
 
@@ -185,7 +185,7 @@ function mergeScores(
       weightedScore: judge.weightedScore,
       failureCategory: judge.failureCategory,
       reasoning: judge.reasoning,
-      checklistResults: judge.checklistResults,
+      checklistResults: judge.checklistResults ?? [],
     };
   }
 

--- a/src/scorer/scorer.ts
+++ b/src/scorer/scorer.ts
@@ -134,6 +134,7 @@ function mergeScores(
       weightedScore,
       failureCategory,
       reasoning: reasons.join(' | '),
+      checklistResults: judge.checklistResults,
     };
   }
 
@@ -168,6 +169,7 @@ function mergeScores(
       weightedScore,
       failureCategory,
       reasoning: `Deterministic only: ${det.details.join('; ')}`,
+      checklistResults: [],
     };
   }
 
@@ -183,6 +185,7 @@ function mergeScores(
       weightedScore: judge.weightedScore,
       failureCategory: judge.failureCategory,
       reasoning: judge.reasoning,
+      checklistResults: judge.checklistResults,
     };
   }
 
@@ -197,5 +200,6 @@ function mergeScores(
     weightedScore: 0,
     failureCategory: 'agent_error',
     reasoning: 'No scoring method available (no deterministic check or LLM judge criteria defined)',
+    checklistResults: [],
   };
 }

--- a/src/scorer/scorer.ts
+++ b/src/scorer/scorer.ts
@@ -134,7 +134,7 @@ function mergeScores(
       weightedScore,
       failureCategory,
       reasoning: reasons.join(' | '),
-      checklistResults: judge.checklistResults ?? [],
+      checklistResults: judge.checklistResults,
     };
   }
 
@@ -185,7 +185,7 @@ function mergeScores(
       weightedScore: judge.weightedScore,
       failureCategory: judge.failureCategory,
       reasoning: judge.reasoning,
-      checklistResults: judge.checklistResults ?? [],
+      checklistResults: judge.checklistResults,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,12 @@ export type FailureCategory =
   | 'agent_error'
   | 'none';
 
+export interface ChecklistItemResult {
+  item: string;
+  passed: boolean;
+  evidence: string;
+}
+
 export interface JudgeScore {
   taskId: string;
   discovery: number; // 0 or 1
@@ -105,6 +111,7 @@ export interface JudgeScore {
   weightedScore: number; // 0-1 (normalized)
   failureCategory: FailureCategory;
   reasoning: string;
+  checklistResults: ChecklistItemResult[];
 }
 
 export interface JudgeOptions {
@@ -128,6 +135,7 @@ export interface CombinedScore {
   weightedScore: number; // 0-1 normalized
   failureCategory: FailureCategory;
   reasoning: string;
+  checklistResults: ChecklistItemResult[];
   stddev?: ScoreStddev; // Only populated when N >= 2
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,7 +100,7 @@ export type FailureCategory =
 export interface ChecklistItemResult {
   item: string;
   passed: boolean;
-  evidence: string;
+  evidence?: string;
 }
 
 export interface JudgeScore {
@@ -111,7 +111,7 @@ export interface JudgeScore {
   weightedScore: number; // 0-1 (normalized)
   failureCategory: FailureCategory;
   reasoning: string;
-  checklistResults: ChecklistItemResult[];
+  checklistResults?: ChecklistItemResult[];
 }
 
 export interface JudgeOptions {
@@ -135,7 +135,7 @@ export interface CombinedScore {
   weightedScore: number; // 0-1 normalized
   failureCategory: FailureCategory;
   reasoning: string;
-  checklistResults: ChecklistItemResult[];
+  checklistResults?: ChecklistItemResult[];
   stddev?: ScoreStddev; // Only populated when N >= 2
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,7 +111,7 @@ export interface JudgeScore {
   weightedScore: number; // 0-1 (normalized)
   failureCategory: FailureCategory;
   reasoning: string;
-  checklistResults?: ChecklistItemResult[];
+  checklistResults: ChecklistItemResult[];
 }
 
 export interface JudgeOptions {


### PR DESCRIPTION
## Summary

- Add per-item pass/fail verdicts with evidence for each `golden_checklist` item in LLM judge evaluation
- Fix JSON response parser to use balanced-brace extraction (the non-greedy regex broke on nested objects)
- Render checklist results in markdown reports, JSON reports, and GitHub Actions summaries
- `ChecklistItemResult[]` is a required field on `JudgeScore` and `CombinedScore` (empty array when no checklist)

## Test plan

- [ ] `npm run build` passes cleanly
- [ ] Run eval with `golden_checklist` items — verify judge prompt includes checklist instructions, report shows per-item results with evidence
- [ ] Run eval without `golden_checklist` — verify no behavioral change
- [ ] Run multi-run eval — verify aggregated results carry forward checklist data from representative run
- [ ] Verify JSON report includes `checklistResults` array in scored task data

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)