### PR TITLE
Add --compare-results flag for cross-iteration comparison

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -82,6 +82,9 @@ inputs:
   compare-skill:
     description: 'Path to baseline skill directory (e.g., previous version) for A/B comparison'
     required: false
+  compare-results:
+    description: 'Path to previous JSON results file for cross-iteration comparison'
+    required: false
 
 outputs:
   passed:
@@ -102,6 +105,8 @@ outputs:
     description: 'Output quality delta (with minus without skill), only set in compare mode'
   score-delta:
     description: 'Weighted score delta (with minus without skill), only set in compare mode'
+  has-regressions:
+    description: 'Whether any tasks regressed significantly vs. previous results (true/false)'
 
 runs:
   using: 'node20'

--- a/action/index.ts
+++ b/action/index.ts
@@ -99,6 +99,7 @@ async function run(): Promise<void> {
     core.setOutput('report-path', result.reportPath || '');
     core.setOutput('json-path', result.jsonPath || '');
     core.setOutput('feedback-template-path', result.feedbackTemplatePath || '');
+    core.setOutput('has-regressions', 'false');
 
     // Set comparison outputs (--compare mode)
     if (result.comparison) {

--- a/action/index.ts
+++ b/action/index.ts
@@ -36,6 +36,7 @@ async function run(): Promise<void> {
     const feedbackPath = core.getInput('feedback') || undefined;
     const compare = core.getInput('compare') === 'true';
     const compareSkillPath = core.getInput('compare-skill') || undefined;
+    const compareResultsPath = core.getInput('compare-results') || undefined;
 
     // Handle API keys
     const anthropicKey = core.getInput('anthropic-api-key') || process.env.ANTHROPIC_API_KEY;
@@ -88,6 +89,7 @@ async function run(): Promise<void> {
       feedbackPath,
       compare: compare || !!compareSkillPath,
       compareSkillPath,
+      compareResultsPath,
     });
 
     // Set outputs
@@ -98,11 +100,17 @@ async function run(): Promise<void> {
     core.setOutput('json-path', result.jsonPath || '');
     core.setOutput('feedback-template-path', result.feedbackTemplatePath || '');
 
-    // Set comparison outputs
+    // Set comparison outputs (--compare mode)
     if (result.comparison) {
       core.setOutput('adherence-delta', String(result.comparison.summary.delta.avgAdherenceDelta));
       core.setOutput('output-delta', String(result.comparison.summary.delta.avgOutputQualityDelta));
       core.setOutput('score-delta', String(result.comparison.summary.delta.avgWeightedScoreDelta));
+    }
+
+    // Set cross-iteration comparison outputs (--compare-results mode)
+    if (result.crossIterationComparison) {
+      const hasRegressions = result.crossIterationComparison.taskDeltas.some((t) => t.significantChange === 'regressed');
+      core.setOutput('has-regressions', String(hasRegressions));
     }
 
     // Write job summary

--- a/src/__tests__/comparison.test.ts
+++ b/src/__tests__/comparison.test.ts
@@ -10,6 +10,7 @@ import {
   SIGNIFICANCE_THRESHOLD_ADHERENCE,
   SIGNIFICANCE_THRESHOLD_WEIGHTED,
 } from '../report/comparison.js';
+import { formatDelta, formatCategory } from '../report/format-utils.js';
 import type {
   EvaluationReport,
   EvaluationSummary,
@@ -455,5 +456,131 @@ describe('formatComparisonConsole', () => {
 
     expect(output).toContain('Improved (1): task-1');
     expect(output).toContain('Regressed (1): task-2');
+  });
+
+  it('shows new and removed task labels', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1' }),
+      makeScore({ taskId: 'task-3' }),
+    ];
+    const comparison = compareResults(currentScores, makeSummary(), previous);
+    const output = formatComparisonConsole(comparison);
+
+    expect(output).toContain('New tasks: task-3');
+    expect(output).toContain('Removed tasks: task-2');
+  });
+
+  it('omits new/removed labels when all tasks match', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1' }),
+      makeScore({ taskId: 'task-2' }),
+    ];
+    const comparison = compareResults(currentScores, makeSummary(), previous);
+    const output = formatComparisonConsole(comparison);
+
+    expect(output).not.toContain('New tasks');
+    expect(output).not.toContain('Removed tasks');
+  });
+});
+
+describe('formatDelta', () => {
+  it('adds + prefix for positive values', () => {
+    expect(formatDelta(1.5)).toBe('+1.50');
+  });
+
+  it('shows no prefix for negative values (minus is implicit)', () => {
+    expect(formatDelta(-0.75)).toBe('-0.75');
+  });
+
+  it('shows no prefix for zero', () => {
+    expect(formatDelta(0)).toBe('0.00');
+  });
+
+  it('appends suffix when provided', () => {
+    expect(formatDelta(2.5, '%')).toBe('+2.50%');
+    expect(formatDelta(-1.0, '%')).toBe('-1.00%');
+  });
+
+  it('rounds to 2 decimal places', () => {
+    expect(formatDelta(1.999)).toBe('+2.00');
+    expect(formatDelta(0.005)).toBe('+0.01');
+    expect(formatDelta(0.004)).toBe('+0.00');
+  });
+});
+
+describe('formatCategory', () => {
+  it('converts "none" to "No Failure"', () => {
+    expect(formatCategory('none')).toBe('No Failure');
+  });
+
+  it('converts snake_case to Title Case', () => {
+    expect(formatCategory('discovery_failure')).toBe('Discovery Failure');
+    expect(formatCategory('false_positive')).toBe('False Positive');
+    expect(formatCategory('instruction_ambiguity')).toBe('Instruction Ambiguity');
+  });
+
+  it('capitalizes single words', () => {
+    expect(formatCategory('error')).toBe('Error');
+  });
+});
+
+describe('loadPreviousReport - score field validation', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const dir of tmpDirs) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+    tmpDirs.length = 0;
+  });
+
+  async function writeTmpJson(data: unknown): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'comparison-test-'));
+    tmpDirs.push(dir);
+    const filePath = path.join(dir, 'results.json');
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+    return filePath;
+  }
+
+  it('throws for task with missing discovery field', async () => {
+    const filePath = await writeTmpJson({
+      skillName: 'test',
+      summary: {},
+      tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 0.8, adherence: 4, outputQuality: 4 } }],
+    });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('missing numeric score fields');
+  });
+
+  it('throws for task with missing adherence field', async () => {
+    const filePath = await writeTmpJson({
+      skillName: 'test',
+      summary: {},
+      tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 0.8, discovery: 1, outputQuality: 4 } }],
+    });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('missing numeric score fields');
+  });
+
+  it('throws for task with missing outputQuality field', async () => {
+    const filePath = await writeTmpJson({
+      skillName: 'test',
+      summary: {},
+      tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 0.8, discovery: 1, adherence: 4 } }],
+    });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('missing numeric score fields');
+  });
+
+  it('accepts task with all numeric score fields', async () => {
+    const filePath = await writeTmpJson({
+      skillName: 'test',
+      summary: {},
+      tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 0.8, discovery: 1, adherence: 4, outputQuality: 4 } }],
+    });
+    const loaded = await loadPreviousReport(filePath);
+    expect(loaded.tasks).toHaveLength(1);
   });
 });

--- a/src/__tests__/comparison.test.ts
+++ b/src/__tests__/comparison.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import {
+  loadPreviousReport,
+  compareResults,
+  formatComparisonMarkdown,
+  formatComparisonConsole,
+  SIGNIFICANCE_THRESHOLD_ADHERENCE,
+  SIGNIFICANCE_THRESHOLD_WEIGHTED,
+} from '../report/comparison.js';
+import type {
+  EvaluationReport,
+  EvaluationSummary,
+  CombinedScore,
+} from '../types.js';
+
+// Helper to build a minimal valid EvaluationReport
+function makeReport(overrides: Partial<EvaluationReport> = {}): EvaluationReport {
+  return {
+    skillName: 'test-skill',
+    timestamp: '2026-03-07T10:00:00.000Z',
+    passed: true,
+    failureReasons: [],
+    summary: {
+      totalTasks: 2,
+      numRuns: 1,
+      discoveryAccuracy: 0.8,
+      avgAdherence: 4.0,
+      avgOutputQuality: 4.0,
+      avgWeightedScore: 0.75,
+      totalDurationMs: 5000,
+      totalCostUsd: 0.01,
+    },
+    failureBreakdown: [],
+    tasks: [
+      {
+        task: { id: 'task-1', prompt: 'p1', expectedSkillLoad: 'skill', criteria: [], goldenChecklist: [] },
+        result: { taskId: 'task-1', prompt: 'p1', output: 'out1', durationMs: 2500, numTurns: 1, costUsd: 0.005, skillLoads: ['skill'], toolCalls: [], isError: false, errorMessage: '' },
+        score: { taskId: 'task-1', deterministic: null, judge: null, discovery: 1, adherence: 4, outputQuality: 4, weightedScore: 0.8, failureCategory: 'none', reasoning: 'ok' },
+      },
+      {
+        task: { id: 'task-2', prompt: 'p2', expectedSkillLoad: 'skill', criteria: [], goldenChecklist: [] },
+        result: { taskId: 'task-2', prompt: 'p2', output: 'out2', durationMs: 2500, numTurns: 1, costUsd: 0.005, skillLoads: ['skill'], toolCalls: [], isError: false, errorMessage: '' },
+        score: { taskId: 'task-2', deterministic: null, judge: null, discovery: 0.6, adherence: 4, outputQuality: 4, weightedScore: 0.7, failureCategory: 'none', reasoning: 'ok' },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeScore(overrides: Partial<CombinedScore> = {}): CombinedScore {
+  return {
+    taskId: 'task-1',
+    deterministic: null,
+    judge: null,
+    discovery: 1,
+    adherence: 4,
+    outputQuality: 4,
+    weightedScore: 0.8,
+    failureCategory: 'none',
+    reasoning: 'ok',
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<EvaluationSummary> = {}): EvaluationSummary {
+  return {
+    totalTasks: 2,
+    numRuns: 1,
+    discoveryAccuracy: 0.8,
+    avgAdherence: 4.0,
+    avgOutputQuality: 4.0,
+    avgWeightedScore: 0.75,
+    totalDurationMs: 5000,
+    totalCostUsd: 0.01,
+    ...overrides,
+  };
+}
+
+describe('loadPreviousReport', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const dir of tmpDirs) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+    tmpDirs.length = 0;
+  });
+
+  async function writeTmpJson(data: unknown): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'comparison-test-'));
+    tmpDirs.push(dir);
+    const filePath = path.join(dir, 'results.json');
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+    return filePath;
+  }
+
+  it('loads a valid report file', async () => {
+    const report = makeReport();
+    const filePath = await writeTmpJson(report);
+    const loaded = await loadPreviousReport(filePath);
+    expect(loaded.skillName).toBe('test-skill');
+    expect(loaded.tasks).toHaveLength(2);
+  });
+
+  it('throws for file not found', async () => {
+    await expect(loadPreviousReport('/nonexistent/path/results.json'))
+      .rejects.toThrow('Comparison file not found');
+  });
+
+  it('throws for invalid JSON', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'comparison-test-'));
+    tmpDirs.push(dir);
+    const filePath = path.join(dir, 'bad.json');
+    await fs.writeFile(filePath, '{ not valid json');
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('Failed to parse comparison file as JSON');
+  });
+
+  it('throws for missing skillName', async () => {
+    const filePath = await writeTmpJson({ summary: {}, tasks: [] });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('missing "skillName"');
+  });
+
+  it('throws for missing summary', async () => {
+    const filePath = await writeTmpJson({ skillName: 'test', tasks: [] });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('missing "summary"');
+  });
+
+  it('throws for missing tasks array', async () => {
+    const filePath = await writeTmpJson({ skillName: 'test', summary: {} });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('missing "tasks" array');
+  });
+
+  it('throws for task without score.taskId', async () => {
+    const filePath = await writeTmpJson({
+      skillName: 'test',
+      summary: {},
+      tasks: [{ task: {}, result: {}, score: {} }],
+    });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('without score.taskId');
+  });
+
+  it('tolerates extra fields', async () => {
+    const report = { ...makeReport(), extraField: 'hello' };
+    const filePath = await writeTmpJson(report);
+    const loaded = await loadPreviousReport(filePath);
+    expect(loaded.skillName).toBe('test-skill');
+  });
+});
+
+describe('compareResults', () => {
+  it('returns all unchanged for identical results', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', discovery: 1, adherence: 4, outputQuality: 4, weightedScore: 0.8 }),
+      makeScore({ taskId: 'task-2', discovery: 0.6, adherence: 4, outputQuality: 4, weightedScore: 0.7 }),
+    ];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+
+    expect(result.taskDeltas).toHaveLength(2);
+    expect(result.taskDeltas.every((t) => t.significantChange === 'unchanged')).toBe(true);
+    expect(result.taskDeltas[0].delta.discovery).toBe(0);
+    expect(result.taskDeltas[0].delta.adherence).toBe(0);
+    expect(result.tasksOnlyInCurrent).toHaveLength(0);
+    expect(result.tasksOnlyInPrevious).toHaveLength(0);
+
+    // Summary delta should be zero
+    expect(result.summaryDelta.delta.discoveryAccuracy).toBe(0);
+    expect(result.summaryDelta.delta.avgAdherence).toBe(0);
+  });
+
+  it('detects improved task', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', discovery: 1, adherence: 5, outputQuality: 5, weightedScore: 0.95 }),
+      makeScore({ taskId: 'task-2', discovery: 0.6, adherence: 4, outputQuality: 4, weightedScore: 0.7 }),
+    ];
+    const currentSummary = makeSummary({ avgAdherence: 4.5, avgWeightedScore: 0.825 });
+
+    const result = compareResults(currentScores, currentSummary, previous);
+
+    const task1 = result.taskDeltas.find((t) => t.taskId === 'task-1')!;
+    expect(task1.significantChange).toBe('improved');
+    expect(task1.delta.adherence).toBe(1);
+    expect(task1.delta.weightedScore).toBeCloseTo(0.15);
+  });
+
+  it('detects regressed task', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', discovery: 0, adherence: 2, outputQuality: 2, weightedScore: 0.15 }),
+      makeScore({ taskId: 'task-2', discovery: 0.6, adherence: 4, outputQuality: 4, weightedScore: 0.7 }),
+    ];
+    const currentSummary = makeSummary({ avgAdherence: 3.0, avgWeightedScore: 0.425 });
+
+    const result = compareResults(currentScores, currentSummary, previous);
+
+    const task1 = result.taskDeltas.find((t) => t.taskId === 'task-1')!;
+    expect(task1.significantChange).toBe('regressed');
+    expect(task1.delta.adherence).toBe(-2);
+  });
+
+  it('flags significance at boundary (adherence delta = 1)', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', discovery: 1, adherence: 5, outputQuality: 4, weightedScore: 0.85 }),
+      makeScore({ taskId: 'task-2', discovery: 0.6, adherence: 4, outputQuality: 4, weightedScore: 0.7 }),
+    ];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    const task1 = result.taskDeltas.find((t) => t.taskId === 'task-1')!;
+    expect(task1.delta.adherence).toBe(SIGNIFICANCE_THRESHOLD_ADHERENCE);
+    expect(task1.significantChange).toBe('improved');
+  });
+
+  it('detects tasks only in current', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1' }),
+      makeScore({ taskId: 'task-2' }),
+      makeScore({ taskId: 'task-3' }),
+    ];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    expect(result.tasksOnlyInCurrent).toEqual(['task-3']);
+  });
+
+  it('detects tasks only in previous', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1' }),
+    ];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    expect(result.tasksOnlyInPrevious).toEqual(['task-2']);
+    expect(result.taskDeltas).toHaveLength(1);
+  });
+
+  it('handles empty previous (all tasks are new)', () => {
+    const previous = makeReport({ tasks: [], summary: makeSummary({ totalTasks: 0, discoveryAccuracy: 0, avgAdherence: 0, avgOutputQuality: 0, avgWeightedScore: 0 }) });
+    const currentScores = [makeScore({ taskId: 'task-1' })];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    expect(result.taskDeltas).toHaveLength(0);
+    expect(result.tasksOnlyInCurrent).toEqual(['task-1']);
+    expect(result.tasksOnlyInPrevious).toHaveLength(0);
+  });
+
+  it('computes correct summary deltas', () => {
+    const previous = makeReport();
+    const currentSummary = makeSummary({
+      discoveryAccuracy: 0.9,
+      avgAdherence: 4.5,
+      avgOutputQuality: 4.2,
+      avgWeightedScore: 0.85,
+    });
+    const currentScores = [
+      makeScore({ taskId: 'task-1' }),
+      makeScore({ taskId: 'task-2' }),
+    ];
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    expect(result.summaryDelta.delta.discoveryAccuracy).toBeCloseTo(0.1);
+    expect(result.summaryDelta.delta.avgAdherence).toBeCloseTo(0.5);
+    expect(result.summaryDelta.delta.avgOutputQuality).toBeCloseTo(0.2);
+    expect(result.summaryDelta.delta.avgWeightedScore).toBeCloseTo(0.1);
+  });
+
+  it('detects significance by weighted threshold when adherence is unchanged', () => {
+    const previous = makeReport();
+    // Discovery flip: 0 -> 1, which changes weighted score by ~0.3 with default weights
+    const currentScores = [
+      makeScore({ taskId: 'task-1', discovery: 1, adherence: 4, outputQuality: 4, weightedScore: 0.8 }),
+      makeScore({ taskId: 'task-2', discovery: 1, adherence: 4, outputQuality: 4, weightedScore: 0.9 }),
+    ];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    const task2 = result.taskDeltas.find((t) => t.taskId === 'task-2')!;
+    // weightedScore delta = 0.9 - 0.7 = 0.2, which exceeds SIGNIFICANCE_THRESHOLD_WEIGHTED
+    expect(task2.significantChange).toBe('improved');
+  });
+
+  it('stores previous and current values in task deltas', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', discovery: 1, adherence: 5, outputQuality: 5, weightedScore: 0.95 }),
+      makeScore({ taskId: 'task-2', discovery: 0.6, adherence: 4, outputQuality: 4, weightedScore: 0.7 }),
+    ];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    const task1 = result.taskDeltas.find((t) => t.taskId === 'task-1')!;
+    expect(task1.previous).toEqual({ discovery: 1, adherence: 4, outputQuality: 4, weightedScore: 0.8 });
+    expect(task1.current).toEqual({ discovery: 1, adherence: 5, outputQuality: 5, weightedScore: 0.95 });
+  });
+});
+
+describe('formatComparisonMarkdown', () => {
+  it('contains expected headings', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', adherence: 5, weightedScore: 0.95 }),
+      makeScore({ taskId: 'task-2' }),
+    ];
+    const comparison = compareResults(currentScores, makeSummary(), previous);
+    const md = formatComparisonMarkdown(comparison);
+
+    expect(md).toContain('## Comparison vs. Previous');
+    expect(md).toContain('### Summary Changes');
+    expect(md).toContain('### Per-Task Changes');
+  });
+
+  it('shows positive deltas with + prefix', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', adherence: 5, weightedScore: 0.95 }),
+      makeScore({ taskId: 'task-2' }),
+    ];
+    const currentSummary = makeSummary({ avgAdherence: 4.5 });
+    const comparison = compareResults(currentScores, currentSummary, previous);
+    const md = formatComparisonMarkdown(comparison);
+
+    expect(md).toContain('+0.50');
+  });
+
+  it('includes warnings for mismatched tasks', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1' }),
+      makeScore({ taskId: 'task-3' }),
+    ];
+    const comparison = compareResults(currentScores, makeSummary(), previous);
+    const md = formatComparisonMarkdown(comparison);
+
+    expect(md).toContain('### Warnings');
+    expect(md).toContain('`task-3`');
+    expect(md).toContain('`task-2`');
+  });
+
+  it('omits warnings section when no mismatched tasks', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1' }),
+      makeScore({ taskId: 'task-2' }),
+    ];
+    const comparison = compareResults(currentScores, makeSummary(), previous);
+    const md = formatComparisonMarkdown(comparison);
+
+    expect(md).not.toContain('### Warnings');
+  });
+
+  it('shows improved and regressed status labels', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', adherence: 5, outputQuality: 5, weightedScore: 0.95 }),
+      makeScore({ taskId: 'task-2', adherence: 2, outputQuality: 2, weightedScore: 0.15 }),
+    ];
+    const comparison = compareResults(currentScores, makeSummary(), previous);
+    const md = formatComparisonMarkdown(comparison);
+
+    expect(md).toContain('Improved');
+    expect(md).toContain('Regressed');
+  });
+});
+
+describe('formatComparisonConsole', () => {
+  it('contains comparison header and delta values', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', adherence: 5, weightedScore: 0.95 }),
+      makeScore({ taskId: 'task-2' }),
+    ];
+    const currentSummary = makeSummary({ avgAdherence: 4.5 });
+    const comparison = compareResults(currentScores, currentSummary, previous);
+    const output = formatComparisonConsole(comparison);
+
+    expect(output).toContain('Comparison vs. Previous');
+    expect(output).toContain('Adherence');
+    expect(output).toContain('+0.50');
+  });
+
+  it('lists improved and regressed tasks', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', adherence: 5, outputQuality: 5, weightedScore: 0.95 }),
+      makeScore({ taskId: 'task-2', adherence: 2, outputQuality: 2, weightedScore: 0.15 }),
+    ];
+    const comparison = compareResults(currentScores, makeSummary(), previous);
+    const output = formatComparisonConsole(comparison);
+
+    expect(output).toContain('Improved (1): task-1');
+    expect(output).toContain('Regressed (1): task-2');
+  });
+});

--- a/src/__tests__/comparison.test.ts
+++ b/src/__tests__/comparison.test.ts
@@ -153,6 +153,26 @@ describe('loadPreviousReport', () => {
     const loaded = await loadPreviousReport(filePath);
     expect(loaded.skillName).toBe('test-skill');
   });
+
+  it('throws for task with non-numeric weightedScore', async () => {
+    const filePath = await writeTmpJson({
+      skillName: 'test',
+      summary: {},
+      tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 'bad' } }],
+    });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('missing numeric score fields');
+  });
+
+  it('throws for task with missing weightedScore', async () => {
+    const filePath = await writeTmpJson({
+      skillName: 'test',
+      summary: {},
+      tasks: [{ task: {}, result: {}, score: { taskId: 'task-1' } }],
+    });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('missing numeric score fields');
+  });
 });
 
 describe('compareResults', () => {
@@ -292,6 +312,37 @@ describe('compareResults', () => {
     const task2 = result.taskDeltas.find((t) => t.taskId === 'task-2')!;
     // weightedScore delta = 0.9 - 0.7 = 0.2, which exceeds SIGNIFICANCE_THRESHOLD_WEIGHTED
     expect(task2.significantChange).toBe('improved');
+  });
+
+  it('classifies as improved when weightedScore is zero but adherence improved', () => {
+    const previous = makeReport();
+    // Adherence improves by 1 (significant), but weightedScore stays the same
+    const currentScores = [
+      makeScore({ taskId: 'task-1', discovery: 1, adherence: 5, outputQuality: 4, weightedScore: 0.8 }),
+      makeScore({ taskId: 'task-2', discovery: 0.6, adherence: 4, outputQuality: 4, weightedScore: 0.7 }),
+    ];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    const task1 = result.taskDeltas.find((t) => t.taskId === 'task-1')!;
+    expect(task1.delta.adherence).toBe(1);
+    expect(task1.delta.weightedScore).toBe(0);
+    expect(task1.significantChange).toBe('improved');
+  });
+
+  it('classifies as regressed when weightedScore is zero but adherence regressed', () => {
+    const previous = makeReport();
+    const currentScores = [
+      makeScore({ taskId: 'task-1', discovery: 1, adherence: 3, outputQuality: 4, weightedScore: 0.8 }),
+      makeScore({ taskId: 'task-2', discovery: 0.6, adherence: 4, outputQuality: 4, weightedScore: 0.7 }),
+    ];
+    const currentSummary = makeSummary();
+
+    const result = compareResults(currentScores, currentSummary, previous);
+    const task1 = result.taskDeltas.find((t) => t.taskId === 'task-1')!;
+    expect(task1.delta.adherence).toBe(-1);
+    expect(task1.delta.weightedScore).toBe(0);
+    expect(task1.significantChange).toBe('regressed');
   });
 
   it('stores previous and current values in task deltas', () => {

--- a/src/__tests__/comparison.test.ts
+++ b/src/__tests__/comparison.test.ts
@@ -17,6 +17,14 @@ import type {
   CombinedScore,
 } from '../types.js';
 
+// Minimal valid summary object for tests that need to pass summary validation
+const validSummary = {
+  discoveryAccuracy: 0.8,
+  avgAdherence: 4.0,
+  avgOutputQuality: 4.0,
+  avgWeightedScore: 0.75,
+};
+
 // Helper to build a minimal valid EvaluationReport
 function makeReport(overrides: Partial<EvaluationReport> = {}): EvaluationReport {
   return {
@@ -132,8 +140,14 @@ describe('loadPreviousReport', () => {
       .rejects.toThrow('missing "summary"');
   });
 
+  it('throws for summary missing required numeric fields', async () => {
+    const filePath = await writeTmpJson({ skillName: 'test', summary: {}, tasks: [] });
+    await expect(loadPreviousReport(filePath))
+      .rejects.toThrow('summary is missing required numeric fields');
+  });
+
   it('throws for missing tasks array', async () => {
-    const filePath = await writeTmpJson({ skillName: 'test', summary: {} });
+    const filePath = await writeTmpJson({ skillName: 'test', summary: validSummary });
     await expect(loadPreviousReport(filePath))
       .rejects.toThrow('missing "tasks" array');
   });
@@ -141,7 +155,7 @@ describe('loadPreviousReport', () => {
   it('throws for task without score.taskId', async () => {
     const filePath = await writeTmpJson({
       skillName: 'test',
-      summary: {},
+      summary: validSummary,
       tasks: [{ task: {}, result: {}, score: {} }],
     });
     await expect(loadPreviousReport(filePath))
@@ -158,7 +172,7 @@ describe('loadPreviousReport', () => {
   it('throws for task with non-numeric weightedScore', async () => {
     const filePath = await writeTmpJson({
       skillName: 'test',
-      summary: {},
+      summary: validSummary,
       tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 'bad' } }],
     });
     await expect(loadPreviousReport(filePath))
@@ -168,7 +182,7 @@ describe('loadPreviousReport', () => {
   it('throws for task with missing weightedScore', async () => {
     const filePath = await writeTmpJson({
       skillName: 'test',
-      summary: {},
+      summary: validSummary,
       tasks: [{ task: {}, result: {}, score: { taskId: 'task-1' } }],
     });
     await expect(loadPreviousReport(filePath))
@@ -547,7 +561,7 @@ describe('loadPreviousReport - score field validation', () => {
   it('throws for task with missing discovery field', async () => {
     const filePath = await writeTmpJson({
       skillName: 'test',
-      summary: {},
+      summary: validSummary,
       tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 0.8, adherence: 4, outputQuality: 4 } }],
     });
     await expect(loadPreviousReport(filePath))
@@ -557,7 +571,7 @@ describe('loadPreviousReport - score field validation', () => {
   it('throws for task with missing adherence field', async () => {
     const filePath = await writeTmpJson({
       skillName: 'test',
-      summary: {},
+      summary: validSummary,
       tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 0.8, discovery: 1, outputQuality: 4 } }],
     });
     await expect(loadPreviousReport(filePath))
@@ -567,7 +581,7 @@ describe('loadPreviousReport - score field validation', () => {
   it('throws for task with missing outputQuality field', async () => {
     const filePath = await writeTmpJson({
       skillName: 'test',
-      summary: {},
+      summary: validSummary,
       tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 0.8, discovery: 1, adherence: 4 } }],
     });
     await expect(loadPreviousReport(filePath))
@@ -577,7 +591,7 @@ describe('loadPreviousReport - score field validation', () => {
   it('accepts task with all numeric score fields', async () => {
     const filePath = await writeTmpJson({
       skillName: 'test',
-      summary: {},
+      summary: validSummary,
       tasks: [{ task: {}, result: {}, score: { taskId: 'task-1', weightedScore: 0.8, discovery: 1, adherence: 4, outputQuality: 4 } }],
     });
     const loaded = await loadPreviousReport(filePath);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ program
   .option('--generate-feedback <path>', 'Generate feedback template JSON with task IDs after run')
   .option('--feedback <path>', 'Path to human review feedback JSON for judge prompt enrichment')
   .option('--github-summary', 'Write GitHub Actions step summary')
+  .option('--compare-results <path>', 'Path to previous JSON results for comparison')
   .option('--verbose', 'Enable verbose output')
   .option('--compare', 'Run with and without skill to measure skill impact')
   .option('--compare-skill <path>', 'Path to baseline skill directory (e.g., previous version) for A/B comparison')
@@ -73,6 +74,7 @@ program
     generateFeedback?: string;
     feedback?: string;
     githubSummary?: boolean;
+    compareResults?: string;
     verbose?: boolean;
     compare?: boolean;
     compareSkill?: string;
@@ -105,6 +107,7 @@ program
         numRuns: options.runs ? parseInt(options.runs, 10) : undefined,
         generateFeedbackPath: options.generateFeedback,
         feedbackPath: options.feedback,
+        compareResultsPath: options.compareResults,
         verbose: options.verbose,
         compare: options.compare || !!options.compareSkill,
         compareSkillPath: options.compareSkill,

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export { generateReport, generateJsonResults, computeSummary, computeFailureBrea
 export type { ReportOptions } from './report/report.js';
 export { generateGitHubSummary, writeGitHubSummary } from './report/github-summary.js';
 export { loadPreviousReport, compareResults, formatComparisonMarkdown, formatComparisonConsole } from './report/comparison.js';
+export { formatDelta, formatCategory } from './utils/format.js';
 
 // Feedback
 export { generateFeedbackTemplate, writeFeedbackTemplate, loadFeedback, validateFeedback, getFeedbackForTask } from './feedback.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,11 @@ export type {
   TaskComparison,
   ComparisonSummary,
   ComparisonData,
+  ScoreSnapshot,
+  SummarySnapshot,
+  TaskDelta,
+  SummaryDelta,
+  ComparisonResult,
 } from './types.js';
 
 // Config
@@ -65,6 +70,7 @@ export { SessionLogger } from './session/session-logger.js';
 export { generateReport, generateJsonResults, computeSummary, computeFailureBreakdown } from './report/report.js';
 export type { ReportOptions } from './report/report.js';
 export { generateGitHubSummary, writeGitHubSummary } from './report/github-summary.js';
+export { loadPreviousReport, compareResults, formatComparisonMarkdown, formatComparisonConsole } from './report/comparison.js';
 
 // Feedback
 export { generateFeedbackTemplate, writeFeedbackTemplate, loadFeedback, validateFeedback, getFeedbackForTask } from './feedback.js';

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -293,6 +293,14 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
 
   console.log(`Running ${evaluation.tasks.length} task(s) for skill: ${evaluation.skillName}`);
 
+  // 1b. Validate comparison file early (before expensive pipeline run)
+  let previousReport: Awaited<ReturnType<typeof loadPreviousReport>> | undefined;
+  if (options.compareResultsPath) {
+    console.log(`Validating comparison file: ${options.compareResultsPath}`);
+    previousReport = await loadPreviousReport(options.compareResultsPath);
+    console.log('Comparison file validated successfully');
+  }
+
   // 2. Detect skills directory
   let skillsDir = options.skillsDir;
   if (!skillsDir) {
@@ -396,9 +404,8 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
     }
 
     // Compare with previous results if requested (cross-iteration comparison)
-    if (options.compareResultsPath) {
+    if (previousReport) {
       console.log('\n--- Comparing with Previous Results ---\n');
-      const previousReport = await loadPreviousReport(options.compareResultsPath);
       if (previousReport.skillName !== evaluation.skillName) {
         console.warn(`Warning: Skill name mismatch — current: "${evaluation.skillName}", previous: "${previousReport.skillName}"`);
       }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -20,10 +20,12 @@ import { generateReport, generateJsonResults, computeSummary } from './report/re
 import { generateGitHubSummary, writeGitHubSummary } from './report/github-summary.js';
 import { loadConfig, type EvalConfig } from './config.js';
 import { aggregateResults, aggregateScores } from './scorer/aggregator.js';
+import { loadPreviousReport, compareResults, formatComparisonConsole } from './report/comparison.js';
 import type {
   SkillEvaluation,
   TaskResult,
   CombinedScore,
+  ComparisonResult,
   EvaluationReport,
   EvaluationSummary,
   ReportMetadata,
@@ -73,6 +75,8 @@ export interface PipelineOptions {
   noJudge?: boolean;
   /** Number of times to run each task (default: 3) */
   numRuns?: number;
+  /** Path to previous JSON results for comparison */
+  compareResultsPath?: string;
   /** Enable verbose logging */
   verbose?: boolean;
   /** Path to write feedback template JSON after run */
@@ -97,6 +101,7 @@ export interface PipelineResult {
   markdownSummary: string;
   feedbackTemplatePath?: string;
   comparison?: ComparisonData;
+  crossIterationComparison?: ComparisonResult;
 }
 
 /** Internal result from a single evaluation phase. */
@@ -335,6 +340,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   // 3. Run evaluation phase(s)
   let primaryPhase: PhaseResult;
   let comparison: ComparisonData | undefined;
+  let crossIterationComparison: ComparisonResult | undefined;
 
   let needsCleanup = false;
   try {
@@ -388,6 +394,24 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
       needsCleanup = await setupSkills(skillsDir, config, cwd);
       primaryPhase = await runPhase('Evaluation', evaluation, config, cwd, skillsDir, numRuns, scorerOptions, logDir);
     }
+
+    // Compare with previous results if requested (cross-iteration comparison)
+    if (options.compareResultsPath) {
+      console.log('\n--- Comparing with Previous Results ---\n');
+      const previousReport = await loadPreviousReport(options.compareResultsPath);
+      if (previousReport.skillName !== evaluation.skillName) {
+        console.warn(`Warning: Skill name mismatch — current: "${evaluation.skillName}", previous: "${previousReport.skillName}"`);
+      }
+      const currentSummary = computeSummary(primaryPhase.results, primaryPhase.scores, numRuns);
+      crossIterationComparison = compareResults(primaryPhase.scores, currentSummary, previousReport);
+
+      if (crossIterationComparison.tasksOnlyInCurrent.length > 0) {
+        console.warn(`Warning: ${crossIterationComparison.tasksOnlyInCurrent.length} task(s) in current results not found in previous: ${crossIterationComparison.tasksOnlyInCurrent.join(', ')}`);
+      }
+      if (crossIterationComparison.tasksOnlyInPrevious.length > 0) {
+        console.warn(`Warning: ${crossIterationComparison.tasksOnlyInPrevious.length} task(s) in previous results not found in current: ${crossIterationComparison.tasksOnlyInPrevious.join(', ')}`);
+      }
+    }
   } finally {
     if (needsCleanup) {
       await cleanupLocalSkills(cwd);
@@ -417,6 +441,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
     numRuns,
     runDetails: primaryPhase.runDetails,
     comparison,
+    crossIterationComparison,
   };
 
   await generateReport({ ...reportOptions, outputPath: reportPath });
@@ -435,6 +460,9 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   if (comparison) {
     printComparisonSummary(comparison);
   }
+  if (crossIterationComparison) {
+    console.log(formatComparisonConsole(crossIterationComparison));
+  }
 
   return {
     passed: report.passed,
@@ -447,6 +475,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
     jsonPath,
     markdownSummary,
     comparison,
+    crossIterationComparison,
   };
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -405,8 +405,11 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
       const currentSummary = computeSummary(primaryPhase.results, primaryPhase.scores, numRuns);
       crossIterationComparison = compareResults(primaryPhase.scores, currentSummary, previousReport);
 
+      if (crossIterationComparison.taskDeltas.length === 0 && primaryPhase.scores.length > 0) {
+        console.warn('Warning: No tasks matched between current and previous results. Comparison may not be meaningful.');
+      }
       if (crossIterationComparison.tasksOnlyInCurrent.length > 0) {
-        console.warn(`Warning: ${crossIterationComparison.tasksOnlyInCurrent.length} task(s) in current results not found in previous: ${crossIterationComparison.tasksOnlyInCurrent.join(', ')}`);
+        console.warn(`Warning: ${crossIterationComparison.tasksOnlyInCurrent.length} task(s) in current results not found in previous: ${crossIterationComparison.tasksOnlyInCurrent.join(', ')}`)
       }
       if (crossIterationComparison.tasksOnlyInPrevious.length > 0) {
         console.warn(`Warning: ${crossIterationComparison.tasksOnlyInPrevious.length} task(s) in previous results not found in current: ${crossIterationComparison.tasksOnlyInPrevious.join(', ')}`);

--- a/src/report/comparison.ts
+++ b/src/report/comparison.ts
@@ -121,11 +121,12 @@ export function compareResults(
       weightedScore: score.weightedScore,
     };
 
+    const round3 = (v: number) => Math.round(v * 1000) / 1000;
     const delta: ScoreSnapshot = {
-      discovery: current.discovery - prev.discovery,
-      adherence: current.adherence - prev.adherence,
-      outputQuality: current.outputQuality - prev.outputQuality,
-      weightedScore: current.weightedScore - prev.weightedScore,
+      discovery: round3(current.discovery - prev.discovery),
+      adherence: round3(current.adherence - prev.adherence),
+      outputQuality: round3(current.outputQuality - prev.outputQuality),
+      weightedScore: round3(current.weightedScore - prev.weightedScore),
     };
 
     const roundedWeighted = Math.round(delta.weightedScore * 1000) / 1000;
@@ -180,10 +181,10 @@ export function compareResults(
     previous: prevSummary,
     current: currSummary,
     delta: {
-      discoveryAccuracy: currSummary.discoveryAccuracy - prevSummary.discoveryAccuracy,
-      avgAdherence: currSummary.avgAdherence - prevSummary.avgAdherence,
-      avgOutputQuality: currSummary.avgOutputQuality - prevSummary.avgOutputQuality,
-      avgWeightedScore: currSummary.avgWeightedScore - prevSummary.avgWeightedScore,
+      discoveryAccuracy: Math.round((currSummary.discoveryAccuracy - prevSummary.discoveryAccuracy) * 1000) / 1000,
+      avgAdherence: Math.round((currSummary.avgAdherence - prevSummary.avgAdherence) * 1000) / 1000,
+      avgOutputQuality: Math.round((currSummary.avgOutputQuality - prevSummary.avgOutputQuality) * 1000) / 1000,
+      avgWeightedScore: Math.round((currSummary.avgWeightedScore - prevSummary.avgWeightedScore) * 1000) / 1000,
     },
   };
 
@@ -317,7 +318,7 @@ function summaryRow(label: string, prev: string, curr: string, delta: string, va
 function formatTransition(prev: number, curr: number): string {
   const delta = curr - prev;
   const sign = delta > 0 ? '+' : '';
-  const fmt = (v: number) => Number.isInteger(v) ? String(v) : v.toFixed(2);
+  const fmt = (v: number) => v.toFixed(1);
   return `${fmt(prev)} → ${fmt(curr)} (${sign}${fmt(delta)})`;
 }
 

--- a/src/report/comparison.ts
+++ b/src/report/comparison.ts
@@ -16,7 +16,7 @@ import type {
   ScoreSnapshot,
   SummarySnapshot,
 } from '../types.js';
-import { formatDelta } from './format-utils.js';
+import { formatDelta, ARROW_DIRECTION_EPSILON } from './format-utils.js';
 
 export const SIGNIFICANCE_THRESHOLD_ADHERENCE = 1;
 export const SIGNIFICANCE_THRESHOLD_WEIGHTED = 0.15;
@@ -49,6 +49,15 @@ export async function loadPreviousReport(filePath: string): Promise<EvaluationRe
   }
   if (!report.summary || typeof report.summary !== 'object') {
     throw new Error('Comparison file is not a valid EvaluationReport: missing "summary"');
+  }
+  const summary = report.summary as Record<string, unknown>;
+  if (
+    typeof summary.discoveryAccuracy !== 'number' ||
+    typeof summary.avgAdherence !== 'number' ||
+    typeof summary.avgOutputQuality !== 'number' ||
+    typeof summary.avgWeightedScore !== 'number'
+  ) {
+    throw new Error('Comparison file summary is missing required numeric fields');
   }
   if (!Array.isArray(report.tasks)) {
     throw new Error('Comparison file is not a valid EvaluationReport: missing "tasks" array');
@@ -119,9 +128,10 @@ export function compareResults(
       weightedScore: current.weightedScore - prev.weightedScore,
     };
 
+    const roundedWeighted = Math.round(delta.weightedScore * 1000) / 1000;
     const isSignificant =
       Math.abs(delta.adherence) >= SIGNIFICANCE_THRESHOLD_ADHERENCE ||
-      Math.abs(delta.weightedScore) >= SIGNIFICANCE_THRESHOLD_WEIGHTED;
+      Math.abs(roundedWeighted) >= SIGNIFICANCE_THRESHOLD_WEIGHTED;
 
     let significantChange: TaskDelta['significantChange'] = 'unchanged';
     if (isSignificant) {
@@ -274,10 +284,10 @@ export function formatComparisonConsole(comparison: ComparisonResult): string {
   lines.push('-'.repeat(50));
   lines.push('  Comparison vs. Previous');
   lines.push('-'.repeat(50));
-  lines.push(`  Discovery:    ${formatSignedDelta(d.discoveryAccuracy * 100)}%`);
-  lines.push(`  Adherence:    ${formatSignedDelta(d.avgAdherence)}`);
-  lines.push(`  Output:       ${formatSignedDelta(d.avgOutputQuality)}`);
-  lines.push(`  Weighted:     ${formatSignedDelta(d.avgWeightedScore)}`);
+  lines.push(`  Discovery:    ${formatDelta(d.discoveryAccuracy * 100)}%`);
+  lines.push(`  Adherence:    ${formatDelta(d.avgAdherence)}`);
+  lines.push(`  Output:       ${formatDelta(d.avgOutputQuality)}`);
+  lines.push(`  Weighted:     ${formatDelta(d.avgWeightedScore)}`);
 
   const improved = comparison.taskDeltas.filter((t) => t.significantChange === 'improved');
   const regressed = comparison.taskDeltas.filter((t) => t.significantChange === 'regressed');
@@ -300,12 +310,9 @@ export function formatComparisonConsole(comparison: ComparisonResult): string {
 }
 
 function summaryRow(label: string, prev: string, curr: string, delta: string, value: number): string {
-  const arrow = value > 0.001 ? ':arrow_up:' : value < -0.001 ? ':arrow_down:' : '';
+  const arrow = value > ARROW_DIRECTION_EPSILON ? ':arrow_up:' : value < -ARROW_DIRECTION_EPSILON ? ':arrow_down:' : '';
   return `| **${label}** | ${prev} | ${curr} | ${delta} | ${arrow} |`;
 }
-
-// formatSignedDelta is just formatDelta with no suffix
-const formatSignedDelta = formatDelta;
 
 function formatTransition(prev: number, curr: number): string {
   const delta = curr - prev;

--- a/src/report/comparison.ts
+++ b/src/report/comparison.ts
@@ -57,6 +57,9 @@ export async function loadPreviousReport(filePath: string): Promise<EvaluationRe
     if (!task.score || typeof task.score.taskId !== 'string') {
       throw new Error('Comparison file has task entries without score.taskId');
     }
+    if (typeof task.score.weightedScore !== 'number') {
+      throw new Error(`Comparison file task "${task.score.taskId}" is missing numeric score fields`);
+    }
   }
 
   return data as EvaluationReport;
@@ -116,7 +119,13 @@ export function compareResults(
 
     let significantChange: TaskDelta['significantChange'] = 'unchanged';
     if (isSignificant) {
-      significantChange = delta.weightedScore > 0 ? 'improved' : 'regressed';
+      // Use weighted score as primary signal, fall back to adherence for tie-breaking
+      if (delta.weightedScore > 0 || (delta.weightedScore === 0 && delta.adherence > 0)) {
+        significantChange = 'improved';
+      } else if (delta.weightedScore < 0 || (delta.weightedScore === 0 && delta.adherence < 0)) {
+        significantChange = 'regressed';
+      }
+      // else stays 'unchanged' when both deltas are exactly zero
     }
 
     taskDeltas.push({
@@ -302,7 +311,8 @@ function formatSignedDelta(value: number): string {
 function formatTransition(prev: number, curr: number): string {
   const delta = curr - prev;
   const sign = delta > 0 ? '+' : '';
-  return `${prev} → ${curr} (${sign}${delta})`;
+  const fmt = (v: number) => Number.isInteger(v) ? String(v) : v.toFixed(2);
+  return `${fmt(prev)} → ${fmt(curr)} (${sign}${fmt(delta)})`;
 }
 
 function formatTransitionDecimal(prev: number, curr: number): string {

--- a/src/report/comparison.ts
+++ b/src/report/comparison.ts
@@ -1,0 +1,312 @@
+/**
+ * Cross-iteration comparison for skill evaluation results.
+ *
+ * Loads a previous JSON result file, matches tasks by ID,
+ * computes per-task deltas, and formats comparison output.
+ */
+
+import * as fs from 'fs/promises';
+import type {
+  EvaluationReport,
+  EvaluationSummary,
+  CombinedScore,
+  ComparisonResult,
+  TaskDelta,
+  SummaryDelta,
+  ScoreSnapshot,
+  SummarySnapshot,
+} from '../types.js';
+
+export const SIGNIFICANCE_THRESHOLD_ADHERENCE = 1;
+export const SIGNIFICANCE_THRESHOLD_WEIGHTED = 0.15;
+
+/**
+ * Load and validate a previous evaluation report from a JSON file.
+ */
+export async function loadPreviousReport(filePath: string): Promise<EvaluationReport> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Comparison file not found: ${filePath}`);
+    }
+    throw err;
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse comparison file as JSON: ${(err as Error).message}`);
+  }
+
+  const report = data as Record<string, unknown>;
+
+  if (typeof report.skillName !== 'string') {
+    throw new Error('Comparison file is not a valid EvaluationReport: missing "skillName"');
+  }
+  if (!report.summary || typeof report.summary !== 'object') {
+    throw new Error('Comparison file is not a valid EvaluationReport: missing "summary"');
+  }
+  if (!Array.isArray(report.tasks)) {
+    throw new Error('Comparison file is not a valid EvaluationReport: missing "tasks" array');
+  }
+
+  for (const task of report.tasks) {
+    if (!task.score || typeof task.score.taskId !== 'string') {
+      throw new Error('Comparison file has task entries without score.taskId');
+    }
+  }
+
+  return data as EvaluationReport;
+}
+
+/**
+ * Compare current scores against a previous evaluation report.
+ */
+export function compareResults(
+  currentScores: CombinedScore[],
+  currentSummary: EvaluationSummary,
+  previous: EvaluationReport
+): ComparisonResult {
+  // Build lookup from previous tasks
+  const previousMap = new Map<string, ScoreSnapshot>();
+  for (const entry of previous.tasks) {
+    const s = entry.score;
+    previousMap.set(s.taskId, {
+      discovery: s.discovery,
+      adherence: s.adherence,
+      outputQuality: s.outputQuality,
+      weightedScore: s.weightedScore,
+    });
+  }
+
+  // Build lookup of current task IDs
+  const currentIds = new Set(currentScores.map((s) => s.taskId));
+
+  // Compute per-task deltas
+  const taskDeltas: TaskDelta[] = [];
+  const tasksOnlyInCurrent: string[] = [];
+
+  for (const score of currentScores) {
+    const prev = previousMap.get(score.taskId);
+    if (!prev) {
+      tasksOnlyInCurrent.push(score.taskId);
+      continue;
+    }
+
+    const current: ScoreSnapshot = {
+      discovery: score.discovery,
+      adherence: score.adherence,
+      outputQuality: score.outputQuality,
+      weightedScore: score.weightedScore,
+    };
+
+    const delta: ScoreSnapshot = {
+      discovery: current.discovery - prev.discovery,
+      adherence: current.adherence - prev.adherence,
+      outputQuality: current.outputQuality - prev.outputQuality,
+      weightedScore: current.weightedScore - prev.weightedScore,
+    };
+
+    const isSignificant =
+      Math.abs(delta.adherence) >= SIGNIFICANCE_THRESHOLD_ADHERENCE ||
+      Math.abs(delta.weightedScore) >= SIGNIFICANCE_THRESHOLD_WEIGHTED;
+
+    let significantChange: TaskDelta['significantChange'] = 'unchanged';
+    if (isSignificant) {
+      significantChange = delta.weightedScore > 0 ? 'improved' : 'regressed';
+    }
+
+    taskDeltas.push({
+      taskId: score.taskId,
+      previous: prev,
+      current,
+      delta,
+      significantChange,
+    });
+  }
+
+  // Find tasks only in previous
+  const tasksOnlyInPrevious: string[] = [];
+  for (const entry of previous.tasks) {
+    if (!currentIds.has(entry.score.taskId)) {
+      tasksOnlyInPrevious.push(entry.score.taskId);
+    }
+  }
+
+  // Compute summary delta
+  const prevSummary: SummarySnapshot = {
+    discoveryAccuracy: previous.summary.discoveryAccuracy,
+    avgAdherence: previous.summary.avgAdherence,
+    avgOutputQuality: previous.summary.avgOutputQuality,
+    avgWeightedScore: previous.summary.avgWeightedScore,
+  };
+
+  const currSummary: SummarySnapshot = {
+    discoveryAccuracy: currentSummary.discoveryAccuracy,
+    avgAdherence: currentSummary.avgAdherence,
+    avgOutputQuality: currentSummary.avgOutputQuality,
+    avgWeightedScore: currentSummary.avgWeightedScore,
+  };
+
+  const summaryDelta: SummaryDelta = {
+    previous: prevSummary,
+    current: currSummary,
+    delta: {
+      discoveryAccuracy: currSummary.discoveryAccuracy - prevSummary.discoveryAccuracy,
+      avgAdherence: currSummary.avgAdherence - prevSummary.avgAdherence,
+      avgOutputQuality: currSummary.avgOutputQuality - prevSummary.avgOutputQuality,
+      avgWeightedScore: currSummary.avgWeightedScore - prevSummary.avgWeightedScore,
+    },
+  };
+
+  return {
+    previousTimestamp: previous.timestamp,
+    previousSkillName: previous.skillName,
+    summaryDelta,
+    taskDeltas,
+    tasksOnlyInCurrent,
+    tasksOnlyInPrevious,
+  };
+}
+
+/**
+ * Format comparison data as a markdown section for the report.
+ */
+export function formatComparisonMarkdown(comparison: ComparisonResult): string {
+  const lines: string[] = [];
+  const d = comparison.summaryDelta;
+
+  lines.push('## Comparison vs. Previous');
+  lines.push('');
+  lines.push(`**Previous run:** ${comparison.previousTimestamp}`);
+  lines.push('');
+
+  // Summary changes table
+  lines.push('### Summary Changes');
+  lines.push('');
+  lines.push('| Metric | Previous | Current | Delta | |');
+  lines.push('|--------|----------|---------|-------|-|');
+  lines.push(summaryRow('Discovery Accuracy',
+    `${(d.previous.discoveryAccuracy * 100).toFixed(1)}%`,
+    `${(d.current.discoveryAccuracy * 100).toFixed(1)}%`,
+    formatDelta(d.delta.discoveryAccuracy * 100, '%'),
+    d.delta.discoveryAccuracy
+  ));
+  lines.push(summaryRow('Avg Adherence',
+    `${d.previous.avgAdherence.toFixed(2)}/5`,
+    `${d.current.avgAdherence.toFixed(2)}/5`,
+    formatDelta(d.delta.avgAdherence),
+    d.delta.avgAdherence
+  ));
+  lines.push(summaryRow('Avg Output Quality',
+    `${d.previous.avgOutputQuality.toFixed(2)}/5`,
+    `${d.current.avgOutputQuality.toFixed(2)}/5`,
+    formatDelta(d.delta.avgOutputQuality),
+    d.delta.avgOutputQuality
+  ));
+  lines.push(summaryRow('Weighted Score',
+    d.previous.avgWeightedScore.toFixed(2),
+    d.current.avgWeightedScore.toFixed(2),
+    formatDelta(d.delta.avgWeightedScore),
+    d.delta.avgWeightedScore
+  ));
+  lines.push('');
+
+  // Per-task changes table
+  if (comparison.taskDeltas.length > 0) {
+    lines.push('### Per-Task Changes');
+    lines.push('');
+    lines.push('| Task | Discovery | Adherence | Output | Weighted | Status |');
+    lines.push('|------|-----------|-----------|--------|----------|--------|');
+    for (const t of comparison.taskDeltas) {
+      const status = t.significantChange === 'improved'
+        ? ':arrow_up: Improved'
+        : t.significantChange === 'regressed'
+          ? ':arrow_down: Regressed'
+          : 'Unchanged';
+      lines.push(`| ${t.taskId} | ${formatTransition(t.previous.discovery, t.current.discovery)} | ${formatTransition(t.previous.adherence, t.current.adherence)} | ${formatTransition(t.previous.outputQuality, t.current.outputQuality)} | ${formatTransitionDecimal(t.previous.weightedScore, t.current.weightedScore)} | ${status} |`);
+    }
+    lines.push('');
+  }
+
+  // Warnings
+  if (comparison.tasksOnlyInCurrent.length > 0 || comparison.tasksOnlyInPrevious.length > 0) {
+    lines.push('### Warnings');
+    lines.push('');
+    for (const id of comparison.tasksOnlyInCurrent) {
+      lines.push(`- Task \`${id}\` exists in current results but not in previous`);
+    }
+    for (const id of comparison.tasksOnlyInPrevious) {
+      lines.push(`- Task \`${id}\` exists in previous results but not in current`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format comparison data for console output.
+ */
+export function formatComparisonConsole(comparison: ComparisonResult): string {
+  const lines: string[] = [];
+  const d = comparison.summaryDelta.delta;
+
+  lines.push('');
+  lines.push('-'.repeat(50));
+  lines.push('  Comparison vs. Previous');
+  lines.push('-'.repeat(50));
+  lines.push(`  Discovery:    ${formatSignedDelta(d.discoveryAccuracy * 100)}%`);
+  lines.push(`  Adherence:    ${formatSignedDelta(d.avgAdherence)}`);
+  lines.push(`  Output:       ${formatSignedDelta(d.avgOutputQuality)}`);
+  lines.push(`  Weighted:     ${formatSignedDelta(d.avgWeightedScore)}`);
+
+  const improved = comparison.taskDeltas.filter((t) => t.significantChange === 'improved');
+  const regressed = comparison.taskDeltas.filter((t) => t.significantChange === 'regressed');
+
+  if (improved.length > 0) {
+    lines.push(`\n  Improved (${improved.length}): ${improved.map((t) => t.taskId).join(', ')}`);
+  }
+  if (regressed.length > 0) {
+    lines.push(`  Regressed (${regressed.length}): ${regressed.map((t) => t.taskId).join(', ')}`);
+  }
+  if (comparison.tasksOnlyInCurrent.length > 0) {
+    lines.push(`  New tasks: ${comparison.tasksOnlyInCurrent.join(', ')}`);
+  }
+  if (comparison.tasksOnlyInPrevious.length > 0) {
+    lines.push(`  Removed tasks: ${comparison.tasksOnlyInPrevious.join(', ')}`);
+  }
+  lines.push('-'.repeat(50));
+
+  return lines.join('\n');
+}
+
+function summaryRow(label: string, prev: string, curr: string, delta: string, value: number): string {
+  const arrow = value > 0.001 ? ':arrow_up:' : value < -0.001 ? ':arrow_down:' : '';
+  return `| **${label}** | ${prev} | ${curr} | ${delta} | ${arrow} |`;
+}
+
+function formatDelta(value: number, suffix = ''): string {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}${suffix}`;
+}
+
+function formatSignedDelta(value: number): string {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}`;
+}
+
+function formatTransition(prev: number, curr: number): string {
+  const delta = curr - prev;
+  const sign = delta > 0 ? '+' : '';
+  return `${prev} → ${curr} (${sign}${delta})`;
+}
+
+function formatTransitionDecimal(prev: number, curr: number): string {
+  const delta = curr - prev;
+  const sign = delta > 0 ? '+' : '';
+  return `${prev.toFixed(2)} → ${curr.toFixed(2)} (${sign}${delta.toFixed(2)})`;
+}

--- a/src/report/comparison.ts
+++ b/src/report/comparison.ts
@@ -16,6 +16,7 @@ import type {
   ScoreSnapshot,
   SummarySnapshot,
 } from '../types.js';
+import { formatDelta } from './format-utils.js';
 
 export const SIGNIFICANCE_THRESHOLD_ADHERENCE = 1;
 export const SIGNIFICANCE_THRESHOLD_WEIGHTED = 0.15;
@@ -57,7 +58,12 @@ export async function loadPreviousReport(filePath: string): Promise<EvaluationRe
     if (!task.score || typeof task.score.taskId !== 'string') {
       throw new Error('Comparison file has task entries without score.taskId');
     }
-    if (typeof task.score.weightedScore !== 'number') {
+    if (
+      typeof task.score.weightedScore !== 'number' ||
+      typeof task.score.discovery !== 'number' ||
+      typeof task.score.adherence !== 'number' ||
+      typeof task.score.outputQuality !== 'number'
+    ) {
       throw new Error(`Comparison file task "${task.score.taskId}" is missing numeric score fields`);
     }
   }
@@ -298,15 +304,8 @@ function summaryRow(label: string, prev: string, curr: string, delta: string, va
   return `| **${label}** | ${prev} | ${curr} | ${delta} | ${arrow} |`;
 }
 
-function formatDelta(value: number, suffix = ''): string {
-  const sign = value > 0 ? '+' : '';
-  return `${sign}${value.toFixed(2)}${suffix}`;
-}
-
-function formatSignedDelta(value: number): string {
-  const sign = value > 0 ? '+' : '';
-  return `${sign}${value.toFixed(2)}`;
-}
+// formatSignedDelta is just formatDelta with no suffix
+const formatSignedDelta = formatDelta;
 
 function formatTransition(prev: number, curr: number): string {
   const delta = curr - prev;

--- a/src/report/format-utils.ts
+++ b/src/report/format-utils.ts
@@ -2,6 +2,9 @@
  * Shared formatting utilities for report modules.
  */
 
+/** Threshold below which a delta is considered effectively zero for arrow display. */
+export const ARROW_DIRECTION_EPSILON = 0.001;
+
 /**
  * Format a numeric delta with sign prefix and fixed decimal places.
  */

--- a/src/report/format-utils.ts
+++ b/src/report/format-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared formatting utilities for report modules.
+ */
+
+/**
+ * Format a numeric delta with sign prefix and fixed decimal places.
+ */
+export function formatDelta(value: number, suffix = ''): string {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}${suffix}`;
+}
+
+/**
+ * Format a snake_case failure category as Title Case.
+ */
+export function formatCategory(cat: string): string {
+  if (cat === 'none') return 'No Failure';
+  return cat
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -60,6 +60,32 @@ export function generateGitHubSummary(report: EvaluationReport): string {
     lines.push('');
   }
 
+  // Cross-iteration comparison section
+  if (report.crossIterationComparison) {
+    const c = report.crossIterationComparison;
+    const sd = c.summaryDelta.delta;
+    const arrow = (v: number) => v > 0.001 ? ':arrow_up:' : v < -0.001 ? ':arrow_down:' : '';
+    lines.push('### Comparison vs. Previous');
+    lines.push('');
+    lines.push('| Metric | Delta | |');
+    lines.push('|--------|-------|-|');
+    lines.push(`| Discovery | ${formatDelta(sd.discoveryAccuracy * 100)}% | ${arrow(sd.discoveryAccuracy)} |`);
+    lines.push(`| Adherence | ${formatDelta(sd.avgAdherence)} | ${arrow(sd.avgAdherence)} |`);
+    lines.push(`| Output Quality | ${formatDelta(sd.avgOutputQuality)} | ${arrow(sd.avgOutputQuality)} |`);
+    lines.push(`| Weighted Score | ${formatDelta(sd.avgWeightedScore)} | ${arrow(sd.avgWeightedScore)} |`);
+    lines.push('');
+
+    const regressions = c.taskDeltas.filter((t) => t.significantChange === 'regressed');
+    const improvements = c.taskDeltas.filter((t) => t.significantChange === 'improved');
+    if (regressions.length > 0) {
+      lines.push(`:warning: **${regressions.length} task(s) regressed:** ${regressions.map((t) => t.taskId).join(', ')}`);
+    }
+    if (improvements.length > 0) {
+      lines.push(`:sparkles: **${improvements.length} task(s) improved:** ${improvements.map((t) => t.taskId).join(', ')}`);
+    }
+    lines.push('');
+  }
+
   // Per-task details in collapsible
   const isMultiRun = summary.numRuns > 1;
   lines.push('<details><summary>All task results</summary>');
@@ -144,5 +170,4 @@ export async function writeGitHubSummary(report: EvaluationReport): Promise<bool
   await fs.appendFile(summaryPath, summary + '\n');
   return true;
 }
-
 

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -13,6 +13,7 @@ import type {
   CombinedScore,
 } from '../types.js';
 import { FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
+import { ARROW_DIRECTION_EPSILON } from './format-utils.js';
 
 /**
  * Generate a condensed summary for GitHub Actions.
@@ -64,7 +65,7 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   if (report.crossIterationComparison) {
     const c = report.crossIterationComparison;
     const sd = c.summaryDelta.delta;
-    const arrow = (v: number) => v > 0.001 ? ':arrow_up:' : v < -0.001 ? ':arrow_down:' : '';
+    const arrow = (v: number) => v > ARROW_DIRECTION_EPSILON ? ':arrow_up:' : v < -ARROW_DIRECTION_EPSILON ? ':arrow_down:' : '';
     lines.push('### Comparison vs. Previous');
     lines.push('');
     lines.push('| Metric | Delta | |');

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -11,6 +11,7 @@ import type {
   SkillEvaluation,
   TaskResult,
   CombinedScore,
+  ComparisonResult,
   EvaluationReport,
   EvaluationSummary,
   FailureBreakdown,
@@ -21,6 +22,7 @@ import type {
 } from '../types.js';
 import { loadConfigSync } from '../config.js';
 import { FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
+import { formatComparisonMarkdown } from './comparison.js';
 
 export interface ReportOptions {
   evaluation: SkillEvaluation;
@@ -31,24 +33,15 @@ export interface ReportOptions {
   numRuns?: number;
   runDetails?: Array<{ result: TaskResult; score: CombinedScore }>[];
   humanFeedback?: HumanFeedback;
-}
-
-export interface ReportOptions {
-  evaluation: SkillEvaluation;
-  results: TaskResult[];
-  scores: CombinedScore[];
-  outputPath?: string;
-  metadata?: ReportMetadata;
-  numRuns?: number;
-  runDetails?: Array<{ result: TaskResult; score: CombinedScore }>[];
   comparison?: ComparisonData;
+  crossIterationComparison?: ComparisonResult;
 }
 
 /**
  * Generate a markdown report from evaluation results.
  */
 export async function generateReport(options: ReportOptions): Promise<string> {
-  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison } = options;
+  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison, crossIterationComparison } = options;
   const numRuns = options.numRuns ?? 1;
   const config = loadConfigSync();
   const totalTasks = evaluation.tasks.length;
@@ -131,6 +124,11 @@ ${metaSection}
 
   if (comparison) {
     report += generateComparisonSection(comparison);
+  }
+
+  if (crossIterationComparison) {
+    report += '\n---\n\n';
+    report += formatComparisonMarkdown(crossIterationComparison);
   }
 
   report += `\n---\n\n## Task Details\n\n`;
@@ -241,7 +239,7 @@ ${result.output.slice(0, config.reportOutputTruncation) || '(no output)'}
  * Generate JSON report for programmatic analysis.
  */
 export async function generateJsonResults(options: ReportOptions): Promise<EvaluationReport> {
-  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison } = options;
+  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison, crossIterationComparison } = options;
   const numRuns = options.numRuns ?? 1;
   const config = loadConfigSync();
   const summary = computeSummary(results, scores, numRuns);
@@ -294,6 +292,7 @@ export async function generateJsonResults(options: ReportOptions): Promise<Evalu
       ? humanFeedback
       : undefined,
     comparison,
+    crossIterationComparison,
   };
 
   if (outputPath) {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -380,6 +380,7 @@ export function computeFailureBreakdown(scores: CombinedScore[]): FailureBreakdo
 }
 
 
+
 /**
  * Generate the comparison section for the markdown report.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,6 +253,7 @@ export interface EvaluationReport {
   }>;
   humanFeedback?: HumanFeedback;
   comparison?: ComparisonData;
+  crossIterationComparison?: ComparisonResult;
 }
 
 // ============================================
@@ -298,6 +299,48 @@ export interface ComparisonData {
   compareSkillPath?: string;
   summary: ComparisonSummary;
   tasks: TaskComparison[];
+}
+
+/** Score snapshot for cross-iteration comparison */
+export interface ScoreSnapshot {
+  discovery: number;
+  adherence: number;
+  outputQuality: number;
+  weightedScore: number;
+}
+
+/** Summary snapshot for cross-iteration comparison */
+export interface SummarySnapshot {
+  discoveryAccuracy: number;
+  avgAdherence: number;
+  avgOutputQuality: number;
+  avgWeightedScore: number;
+}
+
+/** Per-task delta for cross-iteration comparison */
+export interface TaskDelta {
+  taskId: string;
+  previous: ScoreSnapshot;
+  current: ScoreSnapshot;
+  delta: ScoreSnapshot;
+  significantChange: 'improved' | 'regressed' | 'unchanged';
+}
+
+/** Summary-level delta for cross-iteration comparison */
+export interface SummaryDelta {
+  previous: SummarySnapshot;
+  current: SummarySnapshot;
+  delta: SummarySnapshot;
+}
+
+/** Cross-iteration comparison result (--compare-results) */
+export interface ComparisonResult {
+  previousTimestamp: string;
+  previousSkillName: string;
+  summaryDelta: SummaryDelta;
+  taskDeltas: TaskDelta[];
+  tasksOnlyInCurrent: string[];
+  tasksOnlyInPrevious: string[];
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

Closes #21

- Adds `--compare-results <path>` flag to the `run` command that loads a previous JSON result file, matches tasks by ID, and computes per-task deltas for discovery, adherence, output quality, and weighted score
- Flags tasks that improved or regressed significantly (adherence change >= 1 point or weighted score change >= 0.15)
- Adds comparison sections to markdown report, JSON report, GitHub Actions summary, and console output
- Adds `compare-results` input and `has-regressions` output to the GitHub Action
- Refactors `generateReport`/`generateJsonResults` to use a `ReportOptions` object instead of 8 positional parameters

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] All 69 tests pass (25 new comparison tests + 44 existing)
- [ ] Manual: run an eval, then re-run with `--compare-results <prev.json>` and verify comparison output
- [ ] Manual: run without `--compare-results` and verify no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)