### PR TITLE
Add --compare flag for with/without-skill evaluation

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -75,6 +75,13 @@ inputs:
   feedback:
     description: 'Path to human review feedback JSON for judge prompt enrichment'
     required: false
+  compare:
+    description: 'Run with and without skill to compute impact deltas (true/false)'
+    required: false
+    default: 'false'
+  compare-skill:
+    description: 'Path to alternative skill version for comparison'
+    required: false
 
 outputs:
   passed:
@@ -89,6 +96,12 @@ outputs:
     description: 'Path to generated JSON report'
   feedback-template-path:
     description: 'Path to generated feedback template (if --generate-feedback used)'
+  adherence-delta:
+    description: 'Adherence delta (with minus without skill), only set in compare mode'
+  output-delta:
+    description: 'Output quality delta (with minus without skill), only set in compare mode'
+  score-delta:
+    description: 'Weighted score delta (with minus without skill), only set in compare mode'
 
 runs:
   using: 'node20'

--- a/action/action.yml
+++ b/action/action.yml
@@ -80,7 +80,7 @@ inputs:
     required: false
     default: 'false'
   compare-skill:
-    description: 'Path to alternative skill version for comparison'
+    description: 'Path to baseline skill directory (e.g., previous version) for A/B comparison'
     required: false
 
 outputs:

--- a/action/index.ts
+++ b/action/index.ts
@@ -34,6 +34,8 @@ async function run(): Promise<void> {
     const numRuns = parseInt(core.getInput('runs') || '3', 10);
     const generateFeedbackPath = core.getInput('generate-feedback') || undefined;
     const feedbackPath = core.getInput('feedback') || undefined;
+    const compare = core.getInput('compare') === 'true';
+    const compareSkillPath = core.getInput('compare-skill') || undefined;
 
     // Handle API keys
     const anthropicKey = core.getInput('anthropic-api-key') || process.env.ANTHROPIC_API_KEY;
@@ -84,6 +86,8 @@ async function run(): Promise<void> {
       numRuns,
       generateFeedbackPath,
       feedbackPath,
+      compare: compare || !!compareSkillPath,
+      compareSkillPath,
     });
 
     // Set outputs
@@ -93,6 +97,13 @@ async function run(): Promise<void> {
     core.setOutput('report-path', result.reportPath || '');
     core.setOutput('json-path', result.jsonPath || '');
     core.setOutput('feedback-template-path', result.feedbackTemplatePath || '');
+
+    // Set comparison outputs
+    if (result.comparison) {
+      core.setOutput('adherence-delta', String(result.comparison.summary.delta.avgAdherenceDelta));
+      core.setOutput('output-delta', String(result.comparison.summary.delta.avgOutputQualityDelta));
+      core.setOutput('score-delta', String(result.comparison.summary.delta.avgWeightedScoreDelta));
+    }
 
     // Write job summary
     await core.summary.addRaw(result.markdownSummary).write();

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@ai-sdk/google": "^3.0.34",
         "@ai-sdk/openai": "^3.0.33",
         "@openai/agents": "^0.4.15",
+        "@openrouter/ai-sdk-provider": "^2.2.3",
         "ai": "^6.0.99",
         "openai": "^6.25.0",
         "zod": "^4.0.0"
@@ -48,6 +49,9 @@
           "optional": true
         },
         "@openai/agents": {
+          "optional": true
+        },
+        "@openrouter/ai-sdk-provider": {
           "optional": true
         },
         "ai": {

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -20,7 +20,7 @@ describe('formatDelta', () => {
     expect(formatDelta(1.234, 1)).toBe('+1.2');
     expect(formatDelta(-0.56789, 4)).toBe('-0.5679');
     expect(formatDelta(0, 3)).toBe('0.000');
-    expect(formatDelta(0, 0)).toBe('0.');
+    expect(formatDelta(0, 0)).toBe('0');
   });
 
   it('handles large values', () => {

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { formatDelta } from '../utils/format.js';
+
+describe('formatDelta', () => {
+  it('formats positive values with + prefix', () => {
+    expect(formatDelta(1.5)).toBe('+1.50');
+    expect(formatDelta(0.1)).toBe('+0.10');
+  });
+
+  it('formats negative values with - prefix', () => {
+    expect(formatDelta(-1.5)).toBe('-1.50');
+    expect(formatDelta(-0.01)).toBe('-0.01');
+  });
+
+  it('formats zero without sign prefix', () => {
+    expect(formatDelta(0)).toBe('0.00');
+  });
+
+  it('respects custom decimal places', () => {
+    expect(formatDelta(1.234, 1)).toBe('+1.2');
+    expect(formatDelta(-0.56789, 4)).toBe('-0.5679');
+    expect(formatDelta(0, 3)).toBe('0.000');
+    expect(formatDelta(0, 0)).toBe('0.');
+  });
+
+  it('handles large values', () => {
+    expect(formatDelta(1000)).toBe('+1000.00');
+    expect(formatDelta(-9999.99)).toBe('-9999.99');
+  });
+
+  it('handles very small values', () => {
+    expect(formatDelta(0.001)).toBe('+0.00');
+    expect(formatDelta(0.001, 3)).toBe('+0.001');
+    expect(formatDelta(-0.0001, 4)).toBe('-0.0001');
+  });
+});

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -33,4 +33,11 @@ describe('formatDelta', () => {
     expect(formatDelta(0.001, 3)).toBe('+0.001');
     expect(formatDelta(-0.0001, 4)).toBe('-0.0001');
   });
+
+  it('normalizes negative zero to unsigned zero', () => {
+    expect(formatDelta(-0.004)).toBe('0.00');
+    expect(formatDelta(-0.004, 2)).toBe('0.00');
+    expect(formatDelta(-0.0004, 3)).toBe('0.000');
+    expect(formatDelta(-0.4, 0)).toBe('0');
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,7 @@ program
   .option('--github-summary', 'Write GitHub Actions step summary')
   .option('--verbose', 'Enable verbose output')
   .option('--compare', 'Run with and without skill to measure skill impact')
-  .option('--compare-skill <path>', 'Compare current skill against a previous version')
+  .option('--compare-skill <path>', 'Path to baseline skill directory (e.g., previous version) for A/B comparison')
   .action(async (tasksFile: string, options: {
     runner?: string;
     model?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,8 @@ program
   .option('--feedback <path>', 'Path to human review feedback JSON for judge prompt enrichment')
   .option('--github-summary', 'Write GitHub Actions step summary')
   .option('--verbose', 'Enable verbose output')
+  .option('--compare', 'Run with and without skill to measure skill impact')
+  .option('--compare-skill <path>', 'Compare current skill against a previous version')
   .action(async (tasksFile: string, options: {
     runner?: string;
     model?: string;
@@ -72,6 +74,8 @@ program
     feedback?: string;
     githubSummary?: boolean;
     verbose?: boolean;
+    compare?: boolean;
+    compareSkill?: string;
   }) => {
     try {
       if (options.runner && !VALID_RUNNER_TYPES.includes(options.runner as RunnerType)) {
@@ -102,6 +106,8 @@ program
         generateFeedbackPath: options.generateFeedback,
         feedbackPath: options.feedback,
         verbose: options.verbose,
+        compare: options.compare || !!options.compareSkill,
+        compareSkillPath: options.compareSkill,
       });
 
       if (!result.passed) {
@@ -192,18 +198,18 @@ program
         humanFeedback = Object.keys(validated).length > 0 ? validated : undefined;
       }
 
-      const reportOpts = {
+      const reportOptions = {
         evaluation, results, scores, metadata: data.metadata,
         humanFeedback,
       };
-      const report = await generateReport({ ...reportOpts, outputPath: options.output });
+      const report = await generateReport({ ...reportOptions, outputPath: options.output });
 
       if (!options.output) {
         console.log(report);
       }
 
       if (options.json) {
-        await generateJsonResults({ ...reportOpts, outputPath: options.json });
+        await generateJsonResults({ ...reportOptions, outputPath: options.json });
       }
     } catch (error) {
       console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,11 @@ export type {
   ReportMetadata,
   EvaluationReport,
   HumanFeedback,
+  ComparisonMode,
+  TaskComparisonDelta,
+  TaskComparison,
+  ComparisonSummary,
+  ComparisonData,
 } from './types.js';
 
 // Config

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ export type {
   ReportMetadata,
   EvaluationReport,
   HumanFeedback,
-  ComparisonMode,
   TaskComparisonDelta,
   TaskComparison,
   ComparisonSummary,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -3,6 +3,9 @@
  *
  * Coordinates the full evaluation flow:
  * parse tasks → setup skills → run agent → score → report → check thresholds
+ *
+ * In comparison mode (--compare), runs each task with AND without the skill,
+ * then computes delta metrics showing the skill's impact.
  */
 
 import * as path from 'path';
@@ -21,9 +24,13 @@ import type {
   TaskResult,
   CombinedScore,
   EvaluationReport,
+  EvaluationSummary,
   ReportMetadata,
   EvalTask,
   HumanFeedback,
+  ComparisonData,
+  ComparisonSummary,
+  TaskComparison,
 } from './types.js';
 import { loadFeedback, writeFeedbackTemplate } from './feedback.js';
 
@@ -71,6 +78,10 @@ export interface PipelineOptions {
   generateFeedbackPath?: string;
   /** Path to feedback JSON for judge prompt enrichment */
   feedbackPath?: string;
+  /** Enable comparison mode: run with AND without skill */
+  compare?: boolean;
+  /** Path to alternative skill for comparison (instead of no-skill baseline) */
+  compareSkillPath?: string;
 }
 
 export interface PipelineResult {
@@ -84,6 +95,158 @@ export interface PipelineResult {
   jsonPath?: string;
   markdownSummary: string;
   feedbackTemplatePath?: string;
+  comparison?: ComparisonData;
+}
+
+/** Internal result from a single evaluation phase. */
+interface PhaseResult {
+  results: TaskResult[];
+  scores: CombinedScore[];
+  allResults: TaskResult[][];
+  allScores: CombinedScore[][];
+  summary: EvaluationSummary;
+  runDetails: Array<{ result: TaskResult; score: CombinedScore }>[];
+}
+
+/**
+ * Run a single evaluation phase (with or without skills).
+ *
+ * Encapsulates: create runner → run N times → score → aggregate.
+ */
+async function runPhase(
+  phaseLabel: string,
+  evaluation: SkillEvaluation,
+  config: EvalConfig,
+  cwd: string,
+  skillsDir: string | undefined,
+  numRuns: number,
+  scorerOptions: ScorerOptions,
+  logBaseDir: string,
+): Promise<PhaseResult> {
+  const runner = await createRunner(config.runnerType, {
+    cwd,
+    model: config.defaultAgentModel,
+    parallel: false,
+    allowedWriteDirs: config.allowedWriteDirs,
+    skillsDir,
+  }, config);
+
+  const allResults: TaskResult[][] = [];
+  const allScores: CombinedScore[][] = [];
+
+  for (let run = 0; run < numRuns; run++) {
+    if (numRuns > 1) {
+      console.log(`\n--- ${phaseLabel}: Run ${run + 1}/${numRuns} (${config.runnerType}) ---\n`);
+    } else {
+      console.log(`\n--- ${phaseLabel}: Running Tasks (${config.runnerType}) ---\n`);
+    }
+
+    const runLogDir = numRuns > 1 ? path.join(logBaseDir, `run-${run + 1}`) : logBaseDir;
+    const results = await runner.runAll(
+      evaluation,
+      (task: EvalTask) => new SessionLogger(task.id, runLogDir)
+    );
+    allResults.push(results);
+
+    if (numRuns > 1) {
+      console.log(`\n--- ${phaseLabel}: Scoring Run ${run + 1}/${numRuns} ---\n`);
+    } else {
+      console.log(`\n--- ${phaseLabel}: Scoring ---\n`);
+    }
+    const scores = await scoreAll(evaluation.tasks, results, scorerOptions);
+    allScores.push(scores);
+  }
+
+  const results = aggregateResults(allResults, allScores);
+  const scores = aggregateScores(allScores);
+
+  const runDetails: Array<{ result: TaskResult; score: CombinedScore }>[] = [];
+  if (numRuns > 1) {
+    for (let t = 0; t < evaluation.tasks.length; t++) {
+      runDetails.push(
+        allResults.map((r, run) => ({
+          result: r[t],
+          score: allScores[run][t],
+        }))
+      );
+    }
+  }
+
+  const summary = computeSummary(results, scores, numRuns);
+
+  return { results, scores, allResults, allScores, summary, runDetails };
+}
+
+/**
+ * Setup local skills for Claude SDK runner.
+ * Returns true if skills were set up and need cleanup.
+ */
+async function setupSkills(
+  skillsDir: string | undefined,
+  config: EvalConfig,
+  cwd: string,
+): Promise<boolean> {
+  if (!skillsDir) return false;
+  if (config.runnerType === 'claude-sdk') {
+    console.log(`Setting up local skills from: ${skillsDir}`);
+    const skillNames = await setupLocalSkills(skillsDir, cwd);
+    console.log(`Skills configured: ${skillNames.join(', ')}`);
+    return true;
+  }
+  console.log(`Skills directory: ${skillsDir} (${config.runnerType} handles discovery natively)`);
+  return false;
+}
+
+/**
+ * Compute comparison data from with-skill and baseline phase results.
+ */
+function computeComparison(
+  withPhase: PhaseResult,
+  basePhase: PhaseResult,
+  baselineLabel: string,
+  compareSkillPath?: string,
+): ComparisonData {
+  const tasks: TaskComparison[] = [];
+
+  for (let i = 0; i < withPhase.results.length; i++) {
+    const w = { result: withPhase.results[i], score: withPhase.scores[i] };
+    const b = { result: basePhase.results[i], score: basePhase.scores[i] };
+
+    tasks.push({
+      taskId: w.result.taskId,
+      withSkill: w,
+      withoutSkill: b,
+      delta: {
+        taskId: w.result.taskId,
+        adherenceDelta: w.score.adherence - b.score.adherence,
+        outputQualityDelta: w.score.outputQuality - b.score.outputQuality,
+        weightedScoreDelta: w.score.weightedScore - b.score.weightedScore,
+        durationDeltaMs: w.result.durationMs - b.result.durationMs,
+        costDeltaUsd: w.result.costUsd - b.result.costUsd,
+      },
+    });
+  }
+
+  const summary: ComparisonSummary = {
+    withSkill: withPhase.summary,
+    withoutSkill: basePhase.summary,
+    delta: {
+      discoveryAccuracyDelta: withPhase.summary.discoveryAccuracy - basePhase.summary.discoveryAccuracy,
+      avgAdherenceDelta: withPhase.summary.avgAdherence - basePhase.summary.avgAdherence,
+      avgOutputQualityDelta: withPhase.summary.avgOutputQuality - basePhase.summary.avgOutputQuality,
+      avgWeightedScoreDelta: withPhase.summary.avgWeightedScore - basePhase.summary.avgWeightedScore,
+      totalDurationDeltaMs: withPhase.summary.totalDurationMs - basePhase.summary.totalDurationMs,
+      totalCostDeltaUsd: withPhase.summary.totalCostUsd - basePhase.summary.totalCostUsd,
+    },
+    baselineLabel,
+  };
+
+  return {
+    enabled: true,
+    compareSkillPath,
+    summary,
+    tasks,
+  };
 }
 
 /**
@@ -92,12 +255,12 @@ export interface PipelineResult {
 export async function runPipeline(options: PipelineOptions): Promise<PipelineResult> {
   const config = await loadConfig(options.configPath, options.configOverrides);
   const cwd = options.cwd || process.cwd();
+  const compareMode = options.compare || !!options.compareSkillPath;
 
   // 1. Parse tasks
   console.log(`Parsing tasks from: ${options.tasksFile}`);
   let evaluation = await parseEvalFile(options.tasksFile);
 
-  // Filter tasks if specified
   if (options.taskFilter) {
     const filterIds = new Set(options.taskFilter.split(',').map((s) => s.trim()));
     evaluation = {
@@ -124,8 +287,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
 
   console.log(`Running ${evaluation.tasks.length} task(s) for skill: ${evaluation.skillName}`);
 
-  // 2. Setup local skills
-  // Auto-detect skills/ directory relative to tasks file if not explicitly provided
+  // 2. Detect skills directory
   let skillsDir = options.skillsDir;
   if (!skillsDir) {
     const tasksDir = path.dirname(path.resolve(options.tasksFile));
@@ -136,31 +298,47 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
         skillsDir = autoSkillsDir;
       }
     } catch {
-      // No skills/ directory found, that's fine
+      // No skills/ directory found
     }
   }
 
-  // 2b. Setup local skills (Claude SDK copies to .claude/skills/; others pass skillsDir to runner)
-  let skillsSetup = false;
-  if (skillsDir && config.runnerType === 'claude-sdk') {
-    console.log(`Setting up local skills from: ${skillsDir}`);
-    const skillNames = await setupLocalSkills(skillsDir, cwd);
-    skillsSetup = true;
-    console.log(`Skills configured: ${skillNames.join(', ')}`);
-  } else if (skillsDir) {
-    console.log(`Skills directory: ${skillsDir} (${config.runnerType} handles discovery natively)`);
+  // Validate compare-skill path
+  if (options.compareSkillPath) {
+    try {
+      const stat = await fs.stat(options.compareSkillPath);
+      if (!stat.isDirectory()) {
+        throw new Error(`--compare-skill path is not a directory: ${options.compareSkillPath}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`--compare-skill path not found: ${options.compareSkillPath}`);
+      }
+      throw err;
+    }
   }
 
+  if (compareMode && !skillsDir) {
+    console.warn('Warning: --compare used but no skills directory found. Comparison will have no effect.');
+  }
+
+  const numRuns = options.numRuns ?? 3;
+  const logDir = path.join(config.outputDir, 'logs');
+  const scorerOptions: ScorerOptions = {
+    noDeterministic: options.noDeterministic,
+    noJudge: options.noJudge,
+    judgeOptions: { model: config.defaultJudgeModel },
+  };
+
+  // 3. Run evaluation phase(s)
+  let primaryPhase: PhaseResult;
+  let comparison: ComparisonData | undefined;
+
   try {
-    // 3. Run agent against tasks (N times)
-    const numRuns = options.numRuns ?? 3;
-    const runner = await createRunner(config.runnerType, {
-      cwd,
-      model: config.defaultAgentModel,
-      parallel: false,
-      allowedWriteDirs: config.allowedWriteDirs,
-      skillsDir,
-    }, config);
+    if (compareMode && skillsDir) {
+      // --- Comparison mode: two phases ---
+      const baselineLabel = options.compareSkillPath
+        ? path.basename(options.compareSkillPath)
+        : 'No Skill';
 
     const logDir = path.join(config.outputDir, 'logs');
     const scorerOptions: ScorerOptions = {
@@ -170,101 +348,109 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
       humanFeedback,
     };
 
-    const allResults: TaskResult[][] = [];
-    const allScores: CombinedScore[][] = [];
+      console.log(`\nComparison mode: running each task with skill AND ${baselineLabel.toLowerCase()}`);
+      console.log(`Total runs per task: ${numRuns * 2} (${numRuns} with skill + ${numRuns} baseline)\n`);
 
-    for (let run = 0; run < numRuns; run++) {
-      if (numRuns > 1) {
-        console.log(`\n--- Run ${run + 1}/${numRuns} (${config.runnerType}) ---\n`);
-      } else {
-        console.log(`\n--- Running Tasks (${config.runnerType}) ---\n`);
-      }
+      // Phase 1: With Skill
+      console.log('=== Phase 1/2: With Skill ===');
+      await setupSkills(skillsDir, config, cwd);
 
-      const runLogDir = numRuns > 1 ? path.join(logDir, `run-${run + 1}`) : logDir;
-      const results = await runner.runAll(
-        evaluation,
-        (task: EvalTask) => new SessionLogger(task.id, runLogDir)
+      const withPhase = await runPhase(
+        'With Skill', evaluation, config, cwd, skillsDir, numRuns, scorerOptions,
+        path.join(logDir, 'with-skill'),
       );
-      allResults.push(results);
 
-      // Score this run
-      if (numRuns > 1) {
-        console.log(`\n--- Scoring Run ${run + 1}/${numRuns} ---\n`);
-      } else {
-        console.log('\n--- Scoring ---\n');
+      // Clean up between phases
+      if (config.runnerType === 'claude-sdk') {
+        await cleanupLocalSkills(cwd);
       }
-      const scores = await scoreAll(evaluation.tasks, results, scorerOptions);
-      allScores.push(scores);
-    }
 
-    // Aggregate across runs
-    const results = aggregateResults(allResults, allScores);
-    const scores = aggregateScores(allScores);
-
-    // Build per-run details for the report
-    const runDetails: Array<{ result: TaskResult; score: CombinedScore }>[] = [];
-    if (numRuns > 1) {
-      for (let t = 0; t < evaluation.tasks.length; t++) {
-        runDetails.push(
-          allResults.map((r, run) => ({
-            result: r[t],
-            score: allScores[run][t],
-          }))
-        );
+      // Phase 2: Baseline
+      console.log(`\n=== Phase 2/2: ${baselineLabel} ===`);
+      const baseSkillsDir = options.compareSkillPath || undefined;
+      if (baseSkillsDir) {
+        await setupSkills(baseSkillsDir, config, cwd);
       }
+
+      // Baseline skips deterministic scoring (meaningless without expected skill)
+      const baselineScorerOptions: ScorerOptions = {
+        ...scorerOptions,
+        noDeterministic: true,
+      };
+
+      const basePhase = await runPhase(
+        baselineLabel, evaluation, config, cwd, baseSkillsDir, numRuns, baselineScorerOptions,
+        path.join(logDir, 'baseline'),
+      );
+
+      console.log('\n=== Computing Comparison Deltas ===\n');
+      comparison = computeComparison(withPhase, basePhase, baselineLabel, options.compareSkillPath);
+      primaryPhase = withPhase;
+    } else {
+      // --- Normal mode: single phase ---
+      await setupSkills(skillsDir, config, cwd);
+      primaryPhase = await runPhase('Evaluation', evaluation, config, cwd, skillsDir, numRuns, scorerOptions, logDir);
     }
-
-    // 5. Generate reports
-    console.log('\n--- Generating Reports ---\n');
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const reportBaseName = `${evaluation.skillName}-${timestamp}`;
-    const reportPath = path.join(config.outputDir, `${reportBaseName}.md`);
-    const jsonPath = path.join(config.outputDir, `${reportBaseName}.json`);
-
-    const metadata: ReportMetadata = {
-      skillPath: options.tasksFile,
-      runnerType: config.runnerType,
-      agentModel: config.defaultAgentModel,
-      judgeModel: config.defaultJudgeModel,
-    };
-
-    const reportOptions = {
-      evaluation, results, scores, metadata, numRuns, runDetails, humanFeedback,
-    };
-    await generateReport({ ...reportOptions, outputPath: reportPath });
-    const report = await generateJsonResults({ ...reportOptions, outputPath: jsonPath });
-
-    // 6. GitHub summary
-    if (config.githubSummary) {
-      const wrote = await writeGitHubSummary(report);
-      if (wrote) {
-        console.log('GitHub step summary written');
-      }
-    }
-
-    const markdownSummary = generateGitHubSummary(report);
-
-    // 7. Print summary
-    printSummary(report);
-
-    return {
-      passed: report.passed,
-      failureReasons: report.failureReasons,
-      evaluation,
-      results,
-      scores,
-      report,
-      reportPath,
-      jsonPath,
-      markdownSummary,
-      feedbackTemplatePath,
-    };
   } finally {
-    // Cleanup local skills
-    if (skillsSetup) {
+    if (config.runnerType === 'claude-sdk') {
       await cleanupLocalSkills(cwd);
     }
   }
+
+  // 4. Generate reports
+  console.log('\n--- Generating Reports ---\n');
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const suffix = comparison ? 'comparison' : '';
+  const reportBaseName = [evaluation.skillName, suffix, timestamp].filter(Boolean).join('-');
+  const reportPath = path.join(config.outputDir, `${reportBaseName}.md`);
+  const jsonPath = path.join(config.outputDir, `${reportBaseName}.json`);
+
+  const metadata: ReportMetadata = {
+    skillPath: options.tasksFile,
+    runnerType: config.runnerType,
+    agentModel: config.defaultAgentModel,
+    judgeModel: config.defaultJudgeModel,
+  };
+
+  const reportOptions = {
+    evaluation,
+    results: primaryPhase.results,
+    scores: primaryPhase.scores,
+    metadata,
+    numRuns,
+    runDetails: primaryPhase.runDetails,
+    comparison,
+  };
+
+  await generateReport({ ...reportOptions, outputPath: reportPath });
+  const report = await generateJsonResults({ ...reportOptions, outputPath: jsonPath });
+
+  if (config.githubSummary) {
+    const wrote = await writeGitHubSummary(report);
+    if (wrote) {
+      console.log('GitHub step summary written');
+    }
+  }
+
+  const markdownSummary = generateGitHubSummary(report);
+  printSummary(report);
+
+  if (comparison) {
+    printComparisonSummary(comparison);
+  }
+
+  return {
+    passed: report.passed,
+    failureReasons: report.failureReasons,
+    evaluation,
+    results: primaryPhase.results,
+    scores: primaryPhase.scores,
+    report,
+    reportPath,
+    jsonPath,
+    markdownSummary,
+    comparison,
+  };
 }
 
 /**
@@ -357,4 +543,22 @@ function printSummary(report: EvaluationReport): void {
     }
   }
   console.log('='.repeat(50));
+}
+
+function printComparisonSummary(comparison: ComparisonData): void {
+  const d = comparison.summary.delta;
+  console.log('\n' + '-'.repeat(50));
+  console.log(`  Skill Impact (vs ${comparison.summary.baselineLabel})`);
+  console.log('-'.repeat(50));
+  console.log(`  Adherence Delta: ${formatDelta(d.avgAdherenceDelta)}`);
+  console.log(`  Output Quality Delta: ${formatDelta(d.avgOutputQualityDelta)}`);
+  console.log(`  Weighted Score Delta: ${formatDelta(d.avgWeightedScoreDelta, 2)}`);
+  console.log(`  Duration Delta: ${formatDelta(d.totalDurationDeltaMs / 1000, 1)}s`);
+  console.log(`  Cost Delta: $${formatDelta(d.totalCostDeltaUsd, 4)}`);
+  console.log('-'.repeat(50));
+}
+
+function formatDelta(value: number, decimals = 2): string {
+  const sign = value >= 0 ? '+' : '';
+  return `${sign}${value.toFixed(decimals)}`;
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -318,7 +318,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   }
 
   if (compareMode && !skillsDir) {
-    console.warn('Warning: --compare used but no skills directory found. Comparison will have no effect.');
+    console.warn('Warning: --compare used but no skills directory found. Falling back to normal mode (no comparison will be generated).');
   }
 
   const numRuns = options.numRuns ?? 3;
@@ -327,6 +327,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
     noDeterministic: options.noDeterministic,
     noJudge: options.noJudge,
     judgeOptions: { model: config.defaultJudgeModel },
+    humanFeedback,
   };
 
   // 3. Run evaluation phase(s)
@@ -341,15 +342,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
         ? path.basename(options.compareSkillPath)
         : 'No Skill';
 
-    const logDir = path.join(config.outputDir, 'logs');
-    const scorerOptions: ScorerOptions = {
-      noDeterministic: options.noDeterministic,
-      noJudge: options.noJudge,
-      judgeOptions: { model: config.defaultJudgeModel },
-      humanFeedback,
-    };
-
-      console.log(`\nComparison mode: running each task with skill AND ${baselineLabel.toLowerCase()}`);
+      console.log(`\nComparison mode: running each task with skill AND "${baselineLabel}"`);
       console.log(`Total runs per task: ${numRuns * 2} (${numRuns} with skill + ${numRuns} baseline)\n`);
 
       // Phase 1: With Skill
@@ -369,7 +362,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
 
       // Phase 2: Baseline
       console.log(`\n=== Phase 2/2: ${baselineLabel} ===`);
-      const baseSkillsDir = options.compareSkillPath || undefined;
+      const baseSkillsDir = options.compareSkillPath;
       if (baseSkillsDir) {
         needsCleanup = await setupSkills(baseSkillsDir, config, cwd);
       }
@@ -552,6 +545,7 @@ function printComparisonSummary(comparison: ComparisonData): void {
   console.log('\n' + '-'.repeat(50));
   console.log(`  Skill Impact (vs ${comparison.summary.baselineLabel})`);
   console.log('-'.repeat(50));
+  console.log(`  Discovery Delta: ${formatDelta(d.discoveryAccuracyDelta * 100, 0)}%`);
   console.log(`  Adherence Delta: ${formatDelta(d.avgAdherenceDelta)}`);
   console.log(`  Output Quality Delta: ${formatDelta(d.avgOutputQualityDelta)}`);
   console.log(`  Weighted Score Delta: ${formatDelta(d.avgWeightedScoreDelta, 2)}`);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -219,6 +219,7 @@ function computeComparison(
       withoutSkill: b,
       delta: {
         taskId: w.result.taskId,
+        discoveryDelta: w.score.discovery - b.score.discovery,
         adherenceDelta: w.score.adherence - b.score.adherence,
         outputQualityDelta: w.score.outputQuality - b.score.outputQuality,
         weightedScoreDelta: w.score.weightedScore - b.score.weightedScore,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -318,7 +318,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   }
 
   if (compareMode && !skillsDir) {
-    console.warn('Warning: --compare used but no skills directory found. Falling back to normal mode (no comparison will be generated).');
+    throw new Error('--compare requires a skills directory but none was found. Provide a skill via the evaluation YAML or use --compare-skill to specify a baseline skill path.');
   }
 
   const numRuns = options.numRuns ?? 3;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -10,6 +10,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { formatDelta } from './utils/format.js';
 import { parseEvalFile } from './parser.js';
 import { setupLocalSkills, cleanupLocalSkills } from './runner/skill-setup.js';
 import { createRunner } from './runner/runner-factory.js';
@@ -242,7 +243,6 @@ function computeComparison(
   };
 
   return {
-    enabled: true,
     compareSkillPath,
     summary,
     tasks,
@@ -333,6 +333,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   let primaryPhase: PhaseResult;
   let comparison: ComparisonData | undefined;
 
+  let needsCleanup = false;
   try {
     if (compareMode && skillsDir) {
       // --- Comparison mode: two phases ---
@@ -353,7 +354,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
 
       // Phase 1: With Skill
       console.log('=== Phase 1/2: With Skill ===');
-      await setupSkills(skillsDir, config, cwd);
+      needsCleanup = await setupSkills(skillsDir, config, cwd);
 
       const withPhase = await runPhase(
         'With Skill', evaluation, config, cwd, skillsDir, numRuns, scorerOptions,
@@ -361,21 +362,22 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
       );
 
       // Clean up between phases
-      if (config.runnerType === 'claude-sdk') {
+      if (needsCleanup) {
         await cleanupLocalSkills(cwd);
+        needsCleanup = false;
       }
 
       // Phase 2: Baseline
       console.log(`\n=== Phase 2/2: ${baselineLabel} ===`);
       const baseSkillsDir = options.compareSkillPath || undefined;
       if (baseSkillsDir) {
-        await setupSkills(baseSkillsDir, config, cwd);
+        needsCleanup = await setupSkills(baseSkillsDir, config, cwd);
       }
 
-      // Baseline skips deterministic scoring (meaningless without expected skill)
+      // Only skip deterministic for no-skill baseline; version comparison keeps it
       const baselineScorerOptions: ScorerOptions = {
         ...scorerOptions,
-        noDeterministic: true,
+        noDeterministic: options.compareSkillPath ? scorerOptions.noDeterministic : true,
       };
 
       const basePhase = await runPhase(
@@ -388,11 +390,11 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
       primaryPhase = withPhase;
     } else {
       // --- Normal mode: single phase ---
-      await setupSkills(skillsDir, config, cwd);
+      needsCleanup = await setupSkills(skillsDir, config, cwd);
       primaryPhase = await runPhase('Evaluation', evaluation, config, cwd, skillsDir, numRuns, scorerOptions, logDir);
     }
   } finally {
-    if (config.runnerType === 'claude-sdk') {
+    if (needsCleanup) {
       await cleanupLocalSkills(cwd);
     }
   }
@@ -558,7 +560,3 @@ function printComparisonSummary(comparison: ComparisonData): void {
   console.log('-'.repeat(50));
 }
 
-function formatDelta(value: number, decimals = 2): string {
-  const sign = value >= 0 ? '+' : '';
-  return `${sign}${value.toFixed(decimals)}`;
-}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -305,16 +305,17 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
 
   // Validate compare-skill path
   if (options.compareSkillPath) {
+    let stat;
     try {
-      const stat = await fs.stat(options.compareSkillPath);
-      if (!stat.isDirectory()) {
-        throw new Error(`--compare-skill path is not a directory: ${options.compareSkillPath}`);
-      }
+      stat = await fs.stat(options.compareSkillPath);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
         throw new Error(`--compare-skill path not found: ${options.compareSkillPath}`);
       }
       throw err;
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`--compare-skill path is not a directory: ${options.compareSkillPath}`);
     }
   }
 

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -5,7 +5,7 @@
  */
 
 import * as fs from 'fs/promises';
-import { formatDelta } from '../utils/format.js';
+import { formatDelta, formatCategory } from '../utils/format.js';
 import type {
   EvaluationReport,
   EvaluationSummary,
@@ -145,11 +145,4 @@ export async function writeGitHubSummary(report: EvaluationReport): Promise<bool
   return true;
 }
 
-function formatCategory(cat: string): string {
-  if (cat === 'none') return 'No Failure';
-  return cat
-    .split('_')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
-}
 

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -109,6 +109,21 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   lines.push('</details>');
   lines.push('');
 
+  // Comparison section
+  if (report.comparison) {
+    const d = report.comparison.summary.delta;
+    const ws = report.comparison.summary.withSkill;
+    const bs = report.comparison.summary.withoutSkill;
+    lines.push(`### Skill Impact (vs ${report.comparison.summary.baselineLabel})`);
+    lines.push('');
+    lines.push('| Metric | With Skill | Baseline | Delta |');
+    lines.push('|--------|-----------|----------|-------|');
+    lines.push(`| Adherence | ${ws.avgAdherence.toFixed(1)}/5 | ${bs.avgAdherence.toFixed(1)}/5 | **${formatDelta(d.avgAdherenceDelta)}** |`);
+    lines.push(`| Output Quality | ${ws.avgOutputQuality.toFixed(1)}/5 | ${bs.avgOutputQuality.toFixed(1)}/5 | **${formatDelta(d.avgOutputQualityDelta)}** |`);
+    lines.push(`| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | **${formatDelta(d.avgWeightedScoreDelta)}** |`);
+    lines.push('');
+  }
+
   if (!report.passed && report.failureReasons.length > 0) {
     lines.push(`**Failure reasons:** ${report.failureReasons.join('; ')}`);
   }
@@ -134,4 +149,9 @@ function formatCategory(cat: string): string {
     .split('_')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ');
+}
+
+function formatDelta(value: number, decimals = 2): string {
+  const sign = value >= 0 ? '+' : '';
+  return `${sign}${value.toFixed(decimals)}`;
 }

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'fs/promises';
+import { formatDelta } from '../utils/format.js';
 import type {
   EvaluationReport,
   EvaluationSummary,
@@ -151,7 +152,3 @@ function formatCategory(cat: string): string {
     .join(' ');
 }
 
-function formatDelta(value: number, decimals = 2): string {
-  const sign = value >= 0 ? '+' : '';
-  return `${sign}${value.toFixed(decimals)}`;
-}

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -119,6 +119,7 @@ export function generateGitHubSummary(report: EvaluationReport): string {
     lines.push('');
     lines.push('| Metric | With Skill | Baseline | Delta |');
     lines.push('|--------|-----------|----------|-------|');
+    lines.push(`| Discovery | ${(ws.discoveryAccuracy * 100).toFixed(0)}% | ${(bs.discoveryAccuracy * 100).toFixed(0)}% | **${formatDelta(d.discoveryAccuracyDelta * 100, 0)}%** |`);
     lines.push(`| Adherence | ${ws.avgAdherence.toFixed(1)}/5 | ${bs.avgAdherence.toFixed(1)}/5 | **${formatDelta(d.avgAdherenceDelta)}** |`);
     lines.push(`| Output Quality | ${ws.avgOutputQuality.toFixed(1)}/5 | ${bs.avgOutputQuality.toFixed(1)}/5 | **${formatDelta(d.avgOutputQualityDelta)}** |`);
     lines.push(`| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | **${formatDelta(d.avgWeightedScoreDelta)}** |`);

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -75,12 +75,15 @@ export async function generateReport(options: ReportOptions): Promise<string> {
 
   // Build report
   const runsLine = numRuns > 1 ? `**Runs per Task:** ${numRuns}\n` : '';
+  const compareLine = comparison
+    ? `**Mode:** Comparison (vs ${comparison.summary.baselineLabel})\n`
+    : '';
 
   let report = `# Skill Evaluation Report: ${evaluation.skillName}
 
 **Generated:** ${new Date().toISOString()}
 **Total Tasks:** ${totalTasks}
-${runsLine}**Result:** ${passed ? 'PASS' : 'FAIL'}
+${runsLine}${compareLine}**Result:** ${passed ? 'PASS' : 'FAIL'}
 ${metaSection}
 ---
 
@@ -403,6 +406,7 @@ function generateComparisonSection(comparison: ComparisonData): string {
 
 | Metric | With Skill | Baseline | Delta | Impact |
 |--------|-----------|----------|-------|--------|
+| Discovery | ${(ws.discoveryAccuracy * 100).toFixed(0)}% | ${(bs.discoveryAccuracy * 100).toFixed(0)}% | ${formatDelta(d.discoveryAccuracyDelta * 100, 0)}% | |
 | Avg Adherence | ${ws.avgAdherence.toFixed(2)}/5 | ${bs.avgAdherence.toFixed(2)}/5 | ${formatDelta(d.avgAdherenceDelta)} | ${qualityImpact(d.avgAdherenceDelta)} |
 | Avg Output Quality | ${ws.avgOutputQuality.toFixed(2)}/5 | ${bs.avgOutputQuality.toFixed(2)}/5 | ${formatDelta(d.avgOutputQualityDelta)} | ${qualityImpact(d.avgOutputQualityDelta)} |
 | Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | ${formatDelta(d.avgWeightedScoreDelta)} | ${qualityImpact(d.avgWeightedScoreDelta)} |
@@ -424,20 +428,27 @@ function generateComparisonSection(comparison: ComparisonData): string {
   return section;
 }
 
+/** Minimum score delta to classify as positive/negative impact (on 0-5 scale). */
+const QUALITY_IMPACT_THRESHOLD = 0.1;
+/** Minimum duration delta (ms) to classify as slower/faster. */
+const DURATION_IMPACT_THRESHOLD_MS = 1000;
+/** Minimum cost delta (USD) to classify as higher/lower. */
+const COST_IMPACT_THRESHOLD_USD = 0.0001;
+
 function qualityImpact(delta: number): string {
-  if (delta > 0.1) return 'Positive';
-  if (delta < -0.1) return 'Negative';
+  if (delta > QUALITY_IMPACT_THRESHOLD) return 'Positive';
+  if (delta < -QUALITY_IMPACT_THRESHOLD) return 'Negative';
   return 'Neutral';
 }
 
 function durationImpact(deltaMs: number): string {
-  if (deltaMs > 1000) return 'Slower';
-  if (deltaMs < -1000) return 'Faster';
+  if (deltaMs > DURATION_IMPACT_THRESHOLD_MS) return 'Slower';
+  if (deltaMs < -DURATION_IMPACT_THRESHOLD_MS) return 'Faster';
   return 'Similar';
 }
 
 function costImpact(delta: number): string {
-  if (delta > 0.0001) return 'Higher';
-  if (delta < -0.0001) return 'Lower';
+  if (delta > COST_IMPACT_THRESHOLD_USD) return 'Higher';
+  if (delta < -COST_IMPACT_THRESHOLD_USD) return 'Lower';
   return 'Similar';
 }

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { formatDelta } from '../utils/format.js';
+import { formatDelta, formatCategory } from '../utils/format.js';
 import type {
   SkillEvaluation,
   TaskResult,
@@ -380,13 +380,6 @@ export function computeFailureBreakdown(scores: CombinedScore[]): FailureBreakdo
     .sort((a, b) => b.count - a.count);
 }
 
-function formatCategory(cat: string): string {
-  if (cat === 'none') return 'No Failure';
-  return cat
-    .split('_')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
-}
 
 /**
  * Generate the comparison section for the markdown report.

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -406,10 +406,10 @@ function generateComparisonSection(comparison: ComparisonData): string {
 
 | Metric | With Skill | Baseline | Delta | Impact |
 |--------|-----------|----------|-------|--------|
-| Discovery | ${(ws.discoveryAccuracy * 100).toFixed(0)}% | ${(bs.discoveryAccuracy * 100).toFixed(0)}% | ${formatDelta(d.discoveryAccuracyDelta * 100, 0)}% | |
+| Discovery | ${(ws.discoveryAccuracy * 100).toFixed(0)}% | ${(bs.discoveryAccuracy * 100).toFixed(0)}% | ${formatDelta(d.discoveryAccuracyDelta * 100, 0)}% | ${qualityImpact(d.discoveryAccuracyDelta)} |
 | Avg Adherence | ${ws.avgAdherence.toFixed(2)}/5 | ${bs.avgAdherence.toFixed(2)}/5 | ${formatDelta(d.avgAdherenceDelta)} | ${qualityImpact(d.avgAdherenceDelta)} |
 | Avg Output Quality | ${ws.avgOutputQuality.toFixed(2)}/5 | ${bs.avgOutputQuality.toFixed(2)}/5 | ${formatDelta(d.avgOutputQualityDelta)} | ${qualityImpact(d.avgOutputQualityDelta)} |
-| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | ${formatDelta(d.avgWeightedScoreDelta)} | ${qualityImpact(d.avgWeightedScoreDelta)} |
+| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | ${formatDelta(d.avgWeightedScoreDelta)} | ${qualityImpact(d.avgWeightedScoreDelta, WEIGHTED_SCORE_IMPACT_THRESHOLD)} |
 | Duration | ${(ws.totalDurationMs / 1000).toFixed(1)}s | ${(bs.totalDurationMs / 1000).toFixed(1)}s | ${formatDelta(d.totalDurationDeltaMs / 1000, 1)}s | ${durationImpact(d.totalDurationDeltaMs)} |
 | Cost | $${ws.totalCostUsd.toFixed(4)} | $${bs.totalCostUsd.toFixed(4)} | $${formatDelta(d.totalCostDeltaUsd, 4)} | ${costImpact(d.totalCostDeltaUsd)} |
 
@@ -428,16 +428,18 @@ function generateComparisonSection(comparison: ComparisonData): string {
   return section;
 }
 
-/** Minimum score delta to classify as positive/negative impact (on 0-5 scale). */
+/** Minimum score delta to classify as positive/negative impact (on 1-5 scale, ~2.5% of range). */
 const QUALITY_IMPACT_THRESHOLD = 0.1;
+/** Minimum weighted score delta (on 0-1 scale, ~2% of range). */
+const WEIGHTED_SCORE_IMPACT_THRESHOLD = 0.02;
 /** Minimum duration delta (ms) to classify as slower/faster. */
 const DURATION_IMPACT_THRESHOLD_MS = 1000;
 /** Minimum cost delta (USD) to classify as higher/lower. */
 const COST_IMPACT_THRESHOLD_USD = 0.0001;
 
-function qualityImpact(delta: number): string {
-  if (delta > QUALITY_IMPACT_THRESHOLD) return 'Positive';
-  if (delta < -QUALITY_IMPACT_THRESHOLD) return 'Negative';
+function qualityImpact(delta: number, threshold = QUALITY_IMPACT_THRESHOLD): string {
+  if (delta > threshold) return 'Positive';
+  if (delta < -threshold) return 'Negative';
   return 'Neutral';
 }
 

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -6,6 +6,7 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { formatDelta } from '../utils/format.js';
 import type {
   SkillEvaluation,
   TaskResult,
@@ -421,11 +422,6 @@ function generateComparisonSection(comparison: ComparisonData): string {
   }
 
   return section;
-}
-
-function formatDelta(value: number, decimals = 2): string {
-  const sign = value >= 0 ? '+' : '';
-  return `${sign}${value.toFixed(decimals)}`;
 }
 
 function qualityImpact(delta: number): string {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -16,6 +16,7 @@ import type {
   FailureCategory,
   ReportMetadata,
   HumanFeedback,
+  ComparisonData,
 } from '../types.js';
 import { loadConfigSync } from '../config.js';
 import { FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
@@ -31,11 +32,22 @@ export interface ReportOptions {
   humanFeedback?: HumanFeedback;
 }
 
+export interface ReportOptions {
+  evaluation: SkillEvaluation;
+  results: TaskResult[];
+  scores: CombinedScore[];
+  outputPath?: string;
+  metadata?: ReportMetadata;
+  numRuns?: number;
+  runDetails?: Array<{ result: TaskResult; score: CombinedScore }>[];
+  comparison?: ComparisonData;
+}
+
 /**
  * Generate a markdown report from evaluation results.
  */
 export async function generateReport(options: ReportOptions): Promise<string> {
-  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback } = options;
+  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison } = options;
   const numRuns = options.numRuns ?? 1;
   const config = loadConfigSync();
   const totalTasks = evaluation.tasks.length;
@@ -111,13 +123,13 @@ ${metaSection}
       const sanitizedId = taskId.replace(/\|/g, '\\|');
       report += `| ${sanitizedId} | ${truncated} | ${addressed} |\n`;
     }
-
-    report += `\n---\n\n`;
-  } else {
-    report += `\n---\n\n`;
   }
 
-  report += `## Task Details\n\n`;
+  if (comparison) {
+    report += generateComparisonSection(comparison);
+  }
+
+  report += `\n---\n\n## Task Details\n\n`;
 
   for (let i = 0; i < evaluation.tasks.length; i++) {
     const task = evaluation.tasks[i];
@@ -225,7 +237,7 @@ ${result.output.slice(0, config.reportOutputTruncation) || '(no output)'}
  * Generate JSON report for programmatic analysis.
  */
 export async function generateJsonResults(options: ReportOptions): Promise<EvaluationReport> {
-  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback } = options;
+  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison } = options;
   const numRuns = options.numRuns ?? 1;
   const config = loadConfigSync();
   const summary = computeSummary(results, scores, numRuns);
@@ -277,6 +289,7 @@ export async function generateJsonResults(options: ReportOptions): Promise<Evalu
     humanFeedback: humanFeedback && Object.keys(humanFeedback).length > 0
       ? humanFeedback
       : undefined,
+    comparison,
   };
 
   if (outputPath) {
@@ -369,4 +382,66 @@ function formatCategory(cat: string): string {
     .split('_')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ');
+}
+
+/**
+ * Generate the comparison section for the markdown report.
+ */
+function generateComparisonSection(comparison: ComparisonData): string {
+  const { summary, tasks } = comparison;
+  const ws = summary.withSkill;
+  const bs = summary.withoutSkill;
+  const d = summary.delta;
+
+  let section = `
+---
+
+## Skill Impact Analysis
+
+**Baseline:** ${summary.baselineLabel}
+
+| Metric | With Skill | Baseline | Delta | Impact |
+|--------|-----------|----------|-------|--------|
+| Avg Adherence | ${ws.avgAdherence.toFixed(2)}/5 | ${bs.avgAdherence.toFixed(2)}/5 | ${formatDelta(d.avgAdherenceDelta)} | ${qualityImpact(d.avgAdherenceDelta)} |
+| Avg Output Quality | ${ws.avgOutputQuality.toFixed(2)}/5 | ${bs.avgOutputQuality.toFixed(2)}/5 | ${formatDelta(d.avgOutputQualityDelta)} | ${qualityImpact(d.avgOutputQualityDelta)} |
+| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | ${formatDelta(d.avgWeightedScoreDelta)} | ${qualityImpact(d.avgWeightedScoreDelta)} |
+| Duration | ${(ws.totalDurationMs / 1000).toFixed(1)}s | ${(bs.totalDurationMs / 1000).toFixed(1)}s | ${formatDelta(d.totalDurationDeltaMs / 1000, 1)}s | ${durationImpact(d.totalDurationDeltaMs)} |
+| Cost | $${ws.totalCostUsd.toFixed(4)} | $${bs.totalCostUsd.toFixed(4)} | $${formatDelta(d.totalCostDeltaUsd, 4)} | ${costImpact(d.totalCostDeltaUsd)} |
+
+### Per-Task Comparison
+
+| Task | Adherence (W / B / Delta) | Output (W / B / Delta) | Weighted (W / B / Delta) |
+|------|--------------------------|----------------------|------------------------|
+`;
+
+  for (const t of tasks) {
+    const w = t.withSkill.score;
+    const b = t.withoutSkill.score;
+    section += `| ${t.taskId} | ${w.adherence.toFixed(1)} / ${b.adherence.toFixed(1)} / ${formatDelta(t.delta.adherenceDelta, 1)} | ${w.outputQuality.toFixed(1)} / ${b.outputQuality.toFixed(1)} / ${formatDelta(t.delta.outputQualityDelta, 1)} | ${w.weightedScore.toFixed(2)} / ${b.weightedScore.toFixed(2)} / ${formatDelta(t.delta.weightedScoreDelta)} |\n`;
+  }
+
+  return section;
+}
+
+function formatDelta(value: number, decimals = 2): string {
+  const sign = value >= 0 ? '+' : '';
+  return `${sign}${value.toFixed(decimals)}`;
+}
+
+function qualityImpact(delta: number): string {
+  if (delta > 0.1) return 'Positive';
+  if (delta < -0.1) return 'Negative';
+  return 'Neutral';
+}
+
+function durationImpact(deltaMs: number): string {
+  if (deltaMs > 1000) return 'Slower';
+  if (deltaMs < -1000) return 'Faster';
+  return 'Similar';
+}
+
+function costImpact(delta: number): string {
+  if (delta > 0.0001) return 'Higher';
+  if (delta < -0.0001) return 'Lower';
+  return 'Similar';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,9 +259,6 @@ export interface EvaluationReport {
 // Comparison Types
 // ============================================
 
-/** Which side of a comparison run this represents */
-export type ComparisonMode = 'with_skill' | 'without_skill';
-
 /** Per-task delta metrics between with-skill and baseline runs */
 export interface TaskComparisonDelta {
   taskId: string;
@@ -297,7 +294,6 @@ export interface ComparisonSummary {
 
 /** Comparison data included in report when --compare is used */
 export interface ComparisonData {
-  enabled: boolean;
   compareSkillPath?: string;
   summary: ComparisonSummary;
   tasks: TaskComparison[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,6 +262,7 @@ export interface EvaluationReport {
 /** Per-task delta metrics between with-skill and baseline runs */
 export interface TaskComparisonDelta {
   taskId: string;
+  discoveryDelta: number;
   adherenceDelta: number;
   outputQualityDelta: number;
   weightedScoreDelta: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,6 +252,55 @@ export interface EvaluationReport {
     runDetails?: Array<{ result: TaskResult; score: CombinedScore }>;
   }>;
   humanFeedback?: HumanFeedback;
+  comparison?: ComparisonData;
+}
+
+// ============================================
+// Comparison Types
+// ============================================
+
+/** Which side of a comparison run this represents */
+export type ComparisonMode = 'with_skill' | 'without_skill';
+
+/** Per-task delta metrics between with-skill and baseline runs */
+export interface TaskComparisonDelta {
+  taskId: string;
+  adherenceDelta: number;
+  outputQualityDelta: number;
+  weightedScoreDelta: number;
+  durationDeltaMs: number;
+  costDeltaUsd: number;
+}
+
+/** Per-task comparison data with both sides */
+export interface TaskComparison {
+  taskId: string;
+  withSkill: { result: TaskResult; score: CombinedScore };
+  withoutSkill: { result: TaskResult; score: CombinedScore };
+  delta: TaskComparisonDelta;
+}
+
+/** Summary-level comparison data */
+export interface ComparisonSummary {
+  withSkill: EvaluationSummary;
+  withoutSkill: EvaluationSummary;
+  delta: {
+    discoveryAccuracyDelta: number;
+    avgAdherenceDelta: number;
+    avgOutputQualityDelta: number;
+    avgWeightedScoreDelta: number;
+    totalDurationDeltaMs: number;
+    totalCostDeltaUsd: number;
+  };
+  baselineLabel: string;
+}
+
+/** Comparison data included in report when --compare is used */
+export interface ComparisonData {
+  enabled: boolean;
+  compareSkillPath?: string;
+  summary: ComparisonSummary;
+  tasks: TaskComparison[];
 }
 
 // ============================================

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -2,6 +2,7 @@
  * Format a numeric delta value with a sign prefix.
  */
 export function formatDelta(value: number, decimals = 2): string {
-  const sign = value >= 0 ? '+' : '';
+  if (value === 0) return `0.${'0'.repeat(decimals)}`;
+  const sign = value > 0 ? '+' : '';
   return `${sign}${value.toFixed(decimals)}`;
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -10,3 +10,14 @@ export function formatDelta(value: number, decimals = 2): string {
   if (formatted === `-${zeroStr}`) return zeroStr;
   return formatted;
 }
+
+/**
+ * Format a failure category slug as a human-readable label.
+ */
+export function formatCategory(cat: string): string {
+  if (cat === 'none') return 'No Failure';
+  return cat
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -2,7 +2,7 @@
  * Format a numeric delta value with a sign prefix.
  */
 export function formatDelta(value: number, decimals = 2): string {
-  if (value === 0) return `0.${'0'.repeat(decimals)}`;
+  if (value === 0) return decimals > 0 ? `0.${'0'.repeat(decimals)}` : '0';
   const sign = value > 0 ? '+' : '';
   return `${sign}${value.toFixed(decimals)}`;
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,7 @@
+/**
+ * Format a numeric delta value with a sign prefix.
+ */
+export function formatDelta(value: number, decimals = 2): string {
+  const sign = value >= 0 ? '+' : '';
+  return `${sign}${value.toFixed(decimals)}`;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -4,5 +4,9 @@
 export function formatDelta(value: number, decimals = 2): string {
   if (value === 0) return decimals > 0 ? `0.${'0'.repeat(decimals)}` : '0';
   const sign = value > 0 ? '+' : '';
-  return `${sign}${value.toFixed(decimals)}`;
+  const formatted = `${sign}${value.toFixed(decimals)}`;
+  // Normalize negative zero strings (e.g. -0.004 → "-0.00" should become "0.00")
+  const zeroStr = decimals > 0 ? `0.${'0'.repeat(decimals)}` : '0';
+  if (formatted === `-${zeroStr}`) return zeroStr;
+  return formatted;
 }


### PR DESCRIPTION
## Summary
- Adds `--compare` CLI flag that runs each eval task **with** and **without** the skill, computing delta metrics (adherence, output quality, weighted score, duration, cost)
- Adds `--compare-skill <path>` to compare current skill against a previous version instead of no-skill baseline
- Refactors `generateReport()`/`generateJsonResults()` to use a single `ReportOptions` object (breaking change)

## Changes
- **`src/types.ts`** — New comparison types: `ComparisonData`, `TaskComparison`, `ComparisonSummary`, `TaskComparisonDelta`
- **`src/pipeline.ts`** — Unified pipeline with `runPhase()` helper; comparison mode runs two phases then computes deltas
- **`src/report/report.ts`** — "Skill Impact Analysis" section with side-by-side scores and per-task deltas; `ReportOptions` object replaces positional params
- **`src/report/github-summary.ts`** — Condensed comparison table in GitHub Actions summary
- **`src/cli.ts`** — `--compare` and `--compare-skill` flags on `run` command
- **`action/action.yml` + `action/index.ts`** — New `compare`/`compare-skill` inputs and `adherence-delta`/`output-delta`/`score-delta` outputs
- **`src/index.ts`** — Exports new comparison types

## Design decisions
- Pass/fail uses "with skill" scores only — comparison data is informational
- Baseline runs skip deterministic scoring (meaningless without expected skill)
- `--runs N` applies to both phases independently (total = 2 × N × tasks)
- Normal mode code path unchanged when `--compare` is not used

Closes #19

## Test plan
- [ ] `npm run build` compiles without errors
- [ ] Normal mode (`run <tasks>`) behavior unchanged
- [ ] `--compare` runs both phases and generates comparison report sections
- [ ] `--compare-skill <path>` uses alternate skill as baseline
- [ ] JSON report includes `comparison` field with structured delta data
- [ ] GitHub Action inputs/outputs work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)