### PR TITLE
Add blind A/B comparison mode for LLM judge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Two methods, run independently or together:
 - **Deterministic** (free): skill activation, marker strings, tool call checks
 - **LLM Judge** (~$0.001/task): discovery (0/1), adherence (1-5), output quality (1-5)
 - **Weighted Score** (0-1): `w_d * discovery + w_a * ((adherence-1)/4) + w_o * ((output-1)/4)`
+- **Blind A/B Comparison** (`--blind-compare`, requires `--compare`): anonymized judge evaluation to detect scoring bias
 
 ## Failure Categories
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -85,6 +85,10 @@ inputs:
   compare-results:
     description: 'Path to previous JSON results file for cross-iteration comparison'
     required: false
+  blind-compare:
+    description: 'Run blind A/B comparison alongside --compare (true/false)'
+    required: false
+    default: 'false'
 
 outputs:
   passed:
@@ -107,6 +111,12 @@ outputs:
     description: 'Weighted score delta (with minus without skill), only set in compare mode'
   has-regressions:
     description: 'Whether any tasks regressed significantly vs. previous results (true/false)'
+  blind-with-skill-preferred:
+    description: 'Number of tasks where blind comparison preferred the with-skill output'
+  blind-without-skill-preferred:
+    description: 'Number of tasks where blind comparison preferred the without-skill output'
+  blind-bias-signals:
+    description: 'Number of tasks where blind comparison disagrees with standard scoring'
 
 runs:
   using: 'node20'

--- a/action/index.ts
+++ b/action/index.ts
@@ -37,6 +37,7 @@ async function run(): Promise<void> {
     const compare = core.getInput('compare') === 'true';
     const compareSkillPath = core.getInput('compare-skill') || undefined;
     const compareResultsPath = core.getInput('compare-results') || undefined;
+    const blindCompare = core.getInput('blind-compare') === 'true';
 
     // Handle API keys
     const anthropicKey = core.getInput('anthropic-api-key') || process.env.ANTHROPIC_API_KEY;
@@ -90,6 +91,7 @@ async function run(): Promise<void> {
       compare: compare || !!compareSkillPath,
       compareSkillPath,
       compareResultsPath,
+      blindCompare,
     });
 
     // Set outputs
@@ -106,6 +108,13 @@ async function run(): Promise<void> {
       core.setOutput('adherence-delta', String(result.comparison.summary.delta.avgAdherenceDelta));
       core.setOutput('output-delta', String(result.comparison.summary.delta.avgOutputQualityDelta));
       core.setOutput('score-delta', String(result.comparison.summary.delta.avgWeightedScoreDelta));
+    }
+
+    // Set blind comparison outputs (--blind-compare mode)
+    if (result.blindComparison) {
+      core.setOutput('blind-with-skill-preferred', String(result.blindComparison.aggregate.withSkillPreferred));
+      core.setOutput('blind-without-skill-preferred', String(result.blindComparison.aggregate.withoutSkillPreferred));
+      core.setOutput('blind-bias-signals', String(result.blindComparison.aggregate.biasSignalCount));
     }
 
     // Set cross-iteration comparison outputs (--compare-results mode)

--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -103,6 +103,7 @@ function computeAggregate(tasks: BlindTaskComparison[]): BlindComparisonData['ag
     withoutSkillPreferred: tasks.filter(t => t.preferredCondition === 'without-skill').length,
     ties: tasks.filter(t => t.preferredCondition === 'tie').length,
     biasSignalCount: tasks.filter(t => t.biasSignal).length,
+    failedCount: tasks.filter(t => t.reasoning === 'Blind judge call failed').length,
   };
 }
 

--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -6,7 +6,7 @@ import type {
   TaskResult,
   CombinedScore,
 } from '../types.js';
-import { blindCompareAll, BLIND_BIAS_THRESHOLD, SkillJudge } from '../scorer/judge.js';
+import { blindCompareAll, BLIND_BIAS_THRESHOLD, SkillJudge, mapPreferredToCondition } from '../scorer/judge.js';
 import { generateReport } from '../report/report.js';
 
 /** Helper to create a minimal TaskResult */
@@ -148,49 +148,25 @@ describe('Blind comparison bias detection', () => {
 });
 
 describe('Blind comparison label mapping', () => {
-  it('maps A preference to with-skill when withSkillLabel is A', () => {
-    const task: BlindTaskComparison = {
-      taskId: 'task-1',
-      withSkillLabel: 'A',
-      outputA: { instructionFollowing: 5, outputQuality: 5 },
-      outputB: { instructionFollowing: 3, outputQuality: 3 },
-      preferred: 'A',
-      reasoning: 'A is better',
-      preferredCondition: 'with-skill',
-      biasSignal: false,
-      failed: false,
-    };
-    expect(task.preferredCondition).toBe('with-skill');
+  it('maps A preference to with-skill when withSkillIsA is true', () => {
+    expect(mapPreferredToCondition('A', true)).toBe('with-skill');
   });
 
-  it('maps B preference to with-skill when withSkillLabel is B', () => {
-    const task: BlindTaskComparison = {
-      taskId: 'task-1',
-      withSkillLabel: 'B',
-      outputA: { instructionFollowing: 3, outputQuality: 3 },
-      outputB: { instructionFollowing: 5, outputQuality: 5 },
-      preferred: 'B',
-      reasoning: 'B is better',
-      preferredCondition: 'with-skill',
-      biasSignal: false,
-      failed: false,
-    };
-    expect(task.preferredCondition).toBe('with-skill');
+  it('maps B preference to with-skill when withSkillIsA is false', () => {
+    expect(mapPreferredToCondition('B', false)).toBe('with-skill');
   });
 
-  it('maps A preference to without-skill when withSkillLabel is B', () => {
-    const task: BlindTaskComparison = {
-      taskId: 'task-1',
-      withSkillLabel: 'B',
-      outputA: { instructionFollowing: 5, outputQuality: 5 },
-      outputB: { instructionFollowing: 3, outputQuality: 3 },
-      preferred: 'A',
-      reasoning: 'A is better',
-      preferredCondition: 'without-skill',
-      biasSignal: false,
-      failed: false,
-    };
-    expect(task.preferredCondition).toBe('without-skill');
+  it('maps A preference to without-skill when withSkillIsA is false', () => {
+    expect(mapPreferredToCondition('A', false)).toBe('without-skill');
+  });
+
+  it('maps B preference to without-skill when withSkillIsA is true', () => {
+    expect(mapPreferredToCondition('B', true)).toBe('without-skill');
+  });
+
+  it('maps tie regardless of label assignment', () => {
+    expect(mapPreferredToCondition('tie', true)).toBe('tie');
+    expect(mapPreferredToCondition('tie', false)).toBe('tie');
   });
 });
 
@@ -501,8 +477,8 @@ describe('generateBlindComparisonSection in markdown report', () => {
         {
           taskId: 'task-2',
           withSkillLabel: 'A',
-          outputA: { instructionFollowing: 3, outputQuality: 3 },
-          outputB: { instructionFollowing: 3, outputQuality: 3 },
+          outputA: { instructionFollowing: 0, outputQuality: 0 },
+          outputB: { instructionFollowing: 0, outputQuality: 0 },
           preferred: 'tie',
           reasoning: 'Blind judge call failed',
           preferredCondition: 'tie',
@@ -558,6 +534,8 @@ describe('generateBlindComparisonSection in markdown report', () => {
 
     // Percentages should be based on evaluated count (1), not total (2)
     expect(markdown).toContain('| With-skill preferred | 1 | 100% |');
+    // Failed tasks show N/A instead of fabricated scores
+    expect(markdown).toContain('| task-2 | A/B | N/A | N/A | N/A | N/A |');
     // Warning about failed calls
     expect(markdown).toContain('1 blind judge call(s) failed and were excluded from preference counts');
   });

--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -7,6 +7,7 @@ import type {
   CombinedScore,
 } from '../types.js';
 import { blindCompareAll, BLIND_BIAS_THRESHOLD, SkillJudge } from '../scorer/judge.js';
+import { generateReport } from '../report/report.js';
 
 /** Helper to create a minimal TaskResult */
 function makeResult(taskId: string, output = 'test output'): TaskResult {
@@ -103,7 +104,7 @@ function computeAggregate(tasks: BlindTaskComparison[]): BlindComparisonData['ag
   return {
     withSkillPreferred: tasks.filter(t => t.preferredCondition === 'with-skill').length,
     withoutSkillPreferred: tasks.filter(t => t.preferredCondition === 'without-skill').length,
-    ties: tasks.filter(t => t.preferredCondition === 'tie').length,
+    ties: tasks.filter(t => t.preferredCondition === 'tie' && !t.failed).length,
     biasSignalCount: tasks.filter(t => t.biasSignal).length,
     failedCount: tasks.filter(t => t.failed).length,
   };
@@ -293,7 +294,7 @@ describe('blindCompareAll integration', () => {
     expect(result.tasks[0].preferredCondition).toBe('tie');
     expect(result.tasks[0].biasSignal).toBe(false);
     expect(result.aggregate.failedCount).toBe(1);
-    expect(result.aggregate.ties).toBe(1);
+    expect(result.aggregate.ties).toBe(0); // failed tasks excluded from ties
   });
 
   it('respects randomFn for deterministic label assignment', async () => {
@@ -348,5 +349,216 @@ describe('blindCompareAll integration', () => {
     expect(starts.length).toBe(3);
     // With Promise.all, all starts happen before the first end
     expect(callOrder.slice(0, 3)).toEqual(['start', 'start', 'start']);
+  });
+
+  it('excludes failed tasks from ties count in aggregate', async () => {
+    let callCount = 0;
+    const mockJudge = {
+      blindCompare: vi.fn().mockImplementation(async () => {
+        callCount++;
+        // First call succeeds with tie, second fails
+        if (callCount === 1) {
+          return {
+            outputA: { instructionFollowing: 3, outputQuality: 3 },
+            outputB: { instructionFollowing: 3, outputQuality: 3 },
+            preferred: 'tie' as const,
+            reasoning: 'Equal',
+          };
+        }
+        return null; // failure
+      }),
+    } as unknown as SkillJudge;
+
+    const tasks = [
+      makeTaskComparison('task-1', 0.5, 0.5),
+      makeTaskComparison('task-2', 0.5, 0.5),
+    ];
+
+    const result = await blindCompareAll(tasks, mockJudge, { randomFn: () => 0.1 });
+
+    expect(result.aggregate.ties).toBe(1); // only successful tie
+    expect(result.aggregate.failedCount).toBe(1); // failed task not in ties
+    expect(result.tasks[1].failed).toBe(true);
+    expect(result.tasks[1].preferredCondition).toBe('tie'); // still tie internally
+  });
+});
+
+describe('--blind-compare validation', () => {
+  it('throws when --blind-compare is used without --compare', async () => {
+    // We import runPipeline dynamically to avoid triggering side effects
+    const { runPipeline } = await import('../pipeline.js');
+
+    await expect(
+      runPipeline({
+        tasksFile: 'nonexistent.yaml',
+        blindCompare: true,
+        // compare is not set
+      })
+    ).rejects.toThrow('--blind-compare requires --compare mode');
+  });
+});
+
+describe('generateBlindComparisonSection in markdown report', () => {
+  it('includes blind comparison table in generated report', async () => {
+    const blindComparison: BlindComparisonData = {
+      tasks: [
+        {
+          taskId: 'task-1',
+          withSkillLabel: 'A',
+          outputA: { instructionFollowing: 5, outputQuality: 5 },
+          outputB: { instructionFollowing: 2, outputQuality: 2 },
+          preferred: 'A',
+          reasoning: 'A is better',
+          preferredCondition: 'with-skill',
+          biasSignal: false,
+          failed: false,
+        },
+        {
+          taskId: 'task-2',
+          withSkillLabel: 'B',
+          outputA: { instructionFollowing: 3, outputQuality: 3 },
+          outputB: { instructionFollowing: 4, outputQuality: 4 },
+          preferred: 'B',
+          reasoning: 'B is better',
+          preferredCondition: 'with-skill',
+          biasSignal: true,
+          failed: false,
+        },
+      ],
+      aggregate: {
+        withSkillPreferred: 2,
+        withoutSkillPreferred: 0,
+        ties: 0,
+        biasSignalCount: 1,
+        failedCount: 0,
+      },
+    };
+
+    const markdown = await generateReport({
+      evaluation: {
+        skillName: 'test-skill',
+        tasks: [{
+          id: 'task-1',
+          prompt: 'Do something',
+          expectedSkillLoad: 'test-skill',
+          criteria: [],
+          goldenChecklist: [],
+        }],
+      },
+      results: [{
+        taskId: 'task-1',
+        prompt: 'Do something',
+        output: 'done',
+        durationMs: 500,
+        numTurns: 1,
+        costUsd: 0.001,
+        skillLoads: ['test-skill'],
+        toolCalls: [],
+        isError: false,
+        errorMessage: '',
+      }],
+      scores: [{
+        taskId: 'task-1',
+        deterministic: null,
+        judge: null,
+        discovery: 1,
+        adherence: 5,
+        outputQuality: 5,
+        weightedScore: 1,
+        failureCategory: 'none',
+        reasoning: 'Good',
+      }],
+      blindComparison,
+    });
+
+    // Check section header
+    expect(markdown).toContain('## Blind A/B Comparison');
+    // Check preference table
+    expect(markdown).toContain('| With-skill preferred | 2 | 100% |');
+    expect(markdown).toContain('| Without-skill preferred | 0 | 0% |');
+    // Check per-task table
+    expect(markdown).toContain('| Task | Assignment |');
+    expect(markdown).toContain('| task-1 | A/B |');
+    expect(markdown).toContain('| task-2 | B/A |');
+    // Check bias alert
+    expect(markdown).toContain('**Bias Alert:** 1 task(s) show bias signals');
+  });
+
+  it('shows failure warning and excludes failures from percentages', async () => {
+    const blindComparison: BlindComparisonData = {
+      tasks: [
+        {
+          taskId: 'task-1',
+          withSkillLabel: 'A',
+          outputA: { instructionFollowing: 4, outputQuality: 4 },
+          outputB: { instructionFollowing: 3, outputQuality: 3 },
+          preferred: 'A',
+          reasoning: 'A is better',
+          preferredCondition: 'with-skill',
+          biasSignal: false,
+          failed: false,
+        },
+        {
+          taskId: 'task-2',
+          withSkillLabel: 'A',
+          outputA: { instructionFollowing: 3, outputQuality: 3 },
+          outputB: { instructionFollowing: 3, outputQuality: 3 },
+          preferred: 'tie',
+          reasoning: 'Blind judge call failed',
+          preferredCondition: 'tie',
+          biasSignal: false,
+          failed: true,
+        },
+      ],
+      aggregate: {
+        withSkillPreferred: 1,
+        withoutSkillPreferred: 0,
+        ties: 0, // failed task excluded from ties
+        biasSignalCount: 0,
+        failedCount: 1,
+      },
+    };
+
+    const markdown = await generateReport({
+      evaluation: {
+        skillName: 'test-skill',
+        tasks: [{
+          id: 'task-1',
+          prompt: 'Do something',
+          expectedSkillLoad: 'test-skill',
+          criteria: [],
+          goldenChecklist: [],
+        }],
+      },
+      results: [{
+        taskId: 'task-1',
+        prompt: 'Do something',
+        output: 'done',
+        durationMs: 500,
+        numTurns: 1,
+        costUsd: 0.001,
+        skillLoads: ['test-skill'],
+        toolCalls: [],
+        isError: false,
+        errorMessage: '',
+      }],
+      scores: [{
+        taskId: 'task-1',
+        deterministic: null,
+        judge: null,
+        discovery: 1,
+        adherence: 5,
+        outputQuality: 5,
+        weightedScore: 1,
+        failureCategory: 'none',
+        reasoning: 'Good',
+      }],
+      blindComparison,
+    });
+
+    // Percentages should be based on evaluated count (1), not total (2)
+    expect(markdown).toContain('| With-skill preferred | 1 | 100% |');
+    // Warning about failed calls
+    expect(markdown).toContain('1 blind judge call(s) failed and were excluded from preference counts');
   });
 });

--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -78,8 +78,8 @@ function makeBlindTask(
   standardDelta: number,
 ): BlindTaskComparison {
   // Detect bias: standard prefers one, blind prefers the other
-  const standardPrefersWithSkill = standardDelta > 0.02;
-  const standardPrefersWithout = standardDelta < -0.02;
+  const standardPrefersWithSkill = standardDelta > BLIND_BIAS_THRESHOLD;
+  const standardPrefersWithout = standardDelta < -BLIND_BIAS_THRESHOLD;
   const biasSignal =
     preferredCondition !== 'tie' &&
     ((standardPrefersWithSkill && preferredCondition === 'without-skill') ||
@@ -140,7 +140,7 @@ describe('Blind comparison bias detection', () => {
   });
 
   it('no bias when standard delta is within threshold (neutral)', () => {
-    // Standard delta = 0.01, under 0.02 threshold
+    // Standard delta = 0.01, under BLIND_BIAS_THRESHOLD
     const task = makeBlindTask('task-1', 'without-skill', 0.01);
     expect(task.biasSignal).toBe(false);
   });

--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -477,8 +477,8 @@ describe('generateBlindComparisonSection in markdown report', () => {
         {
           taskId: 'task-2',
           withSkillLabel: 'A',
-          outputA: { instructionFollowing: 0, outputQuality: 0 },
-          outputB: { instructionFollowing: 0, outputQuality: 0 },
+          outputA: { instructionFollowing: 1, outputQuality: 1 },
+          outputB: { instructionFollowing: 1, outputQuality: 1 },
           preferred: 'tie',
           reasoning: 'Blind judge call failed',
           preferredCondition: 'tie',

--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type {
   BlindTaskComparison,
   BlindComparisonData,
@@ -6,6 +6,7 @@ import type {
   TaskResult,
   CombinedScore,
 } from '../types.js';
+import { blindCompareAll, BLIND_BIAS_THRESHOLD, SkillJudge } from '../scorer/judge.js';
 
 /** Helper to create a minimal TaskResult */
 function makeResult(taskId: string, output = 'test output'): TaskResult {
@@ -87,8 +88,8 @@ function makeBlindTask(
   return {
     taskId,
     withSkillLabel: 'A',
-    outputA: { adherence: 4, outputQuality: 4 },
-    outputB: { adherence: 3, outputQuality: 3 },
+    outputA: { instructionFollowing: 4, outputQuality: 4 },
+    outputB: { instructionFollowing: 3, outputQuality: 3 },
     preferred: preferredCondition === 'with-skill' ? 'A' : preferredCondition === 'without-skill' ? 'B' : 'tie',
     reasoning: 'test reasoning',
     preferredCondition,
@@ -150,8 +151,8 @@ describe('Blind comparison label mapping', () => {
     const task: BlindTaskComparison = {
       taskId: 'task-1',
       withSkillLabel: 'A',
-      outputA: { adherence: 5, outputQuality: 5 },
-      outputB: { adherence: 3, outputQuality: 3 },
+      outputA: { instructionFollowing: 5, outputQuality: 5 },
+      outputB: { instructionFollowing: 3, outputQuality: 3 },
       preferred: 'A',
       reasoning: 'A is better',
       preferredCondition: 'with-skill',
@@ -165,8 +166,8 @@ describe('Blind comparison label mapping', () => {
     const task: BlindTaskComparison = {
       taskId: 'task-1',
       withSkillLabel: 'B',
-      outputA: { adherence: 3, outputQuality: 3 },
-      outputB: { adherence: 5, outputQuality: 5 },
+      outputA: { instructionFollowing: 3, outputQuality: 3 },
+      outputB: { instructionFollowing: 5, outputQuality: 5 },
       preferred: 'B',
       reasoning: 'B is better',
       preferredCondition: 'with-skill',
@@ -180,8 +181,8 @@ describe('Blind comparison label mapping', () => {
     const task: BlindTaskComparison = {
       taskId: 'task-1',
       withSkillLabel: 'B',
-      outputA: { adherence: 5, outputQuality: 5 },
-      outputB: { adherence: 3, outputQuality: 3 },
+      outputA: { instructionFollowing: 5, outputQuality: 5 },
+      outputB: { instructionFollowing: 3, outputQuality: 3 },
       preferred: 'A',
       reasoning: 'A is better',
       preferredCondition: 'without-skill',
@@ -230,5 +231,122 @@ describe('Blind comparison aggregate computation', () => {
     expect(aggregate.withoutSkillPreferred).toBe(0);
     expect(aggregate.ties).toBe(0);
     expect(aggregate.biasSignalCount).toBe(0);
+  });
+});
+
+describe('blindCompareAll integration', () => {
+  function createMockJudge(
+    response: { outputA: { instructionFollowing: number; outputQuality: number }; outputB: { instructionFollowing: number; outputQuality: number }; preferred: 'A' | 'B' | 'tie'; reasoning: string } | null,
+  ) {
+    return {
+      blindCompare: vi.fn().mockResolvedValue(response),
+    } as unknown as SkillJudge;
+  }
+
+  it('maps judge results and detects bias correctly', async () => {
+    const mockJudge = createMockJudge({
+      outputA: { instructionFollowing: 5, outputQuality: 5 },
+      outputB: { instructionFollowing: 2, outputQuality: 2 },
+      preferred: 'A',
+      reasoning: 'A is clearly better',
+    });
+
+    // Standard scoring prefers with-skill (delta > 0)
+    const tasks = [makeTaskComparison('task-1', 0.8, 0.3)];
+    // Pin randomFn so with-skill is always A
+    const result = await blindCompareAll(tasks, mockJudge, { randomFn: () => 0.1 });
+
+    expect(result.tasks).toHaveLength(1);
+    expect(mockJudge.blindCompare).toHaveBeenCalledOnce();
+    expect(result.tasks[0].withSkillLabel).toBe('A');
+    expect(result.tasks[0].preferredCondition).toBe('with-skill');
+    expect(result.tasks[0].biasSignal).toBe(false); // both agree
+    expect(result.tasks[0].failed).toBe(false);
+    expect(result.aggregate.withSkillPreferred).toBe(1);
+    expect(result.aggregate.ties).toBe(0);
+  });
+
+  it('detects bias when blind disagrees with standard', async () => {
+    // Blind prefers B (without-skill), standard prefers with-skill
+    const mockJudge = createMockJudge({
+      outputA: { instructionFollowing: 2, outputQuality: 2 },
+      outputB: { instructionFollowing: 5, outputQuality: 5 },
+      preferred: 'B',
+      reasoning: 'B is better',
+    });
+
+    const tasks = [makeTaskComparison('task-1', 0.8, 0.3)]; // standard prefers with-skill
+    const result = await blindCompareAll(tasks, mockJudge, { randomFn: () => 0.1 }); // with-skill = A
+
+    expect(result.tasks[0].preferredCondition).toBe('without-skill');
+    expect(result.tasks[0].biasSignal).toBe(true);
+    expect(result.aggregate.biasSignalCount).toBe(1);
+  });
+
+  it('handles failed blind judge calls gracefully', async () => {
+    const mockJudge = createMockJudge(null);
+
+    const tasks = [makeTaskComparison('task-1', 0.8, 0.3)];
+    const result = await blindCompareAll(tasks, mockJudge, { randomFn: () => 0.1 });
+
+    expect(result.tasks[0].failed).toBe(true);
+    expect(result.tasks[0].preferredCondition).toBe('tie');
+    expect(result.tasks[0].biasSignal).toBe(false);
+    expect(result.aggregate.failedCount).toBe(1);
+    expect(result.aggregate.ties).toBe(1);
+  });
+
+  it('respects randomFn for deterministic label assignment', async () => {
+    const mockJudge = createMockJudge({
+      outputA: { instructionFollowing: 3, outputQuality: 3 },
+      outputB: { instructionFollowing: 3, outputQuality: 3 },
+      preferred: 'tie',
+      reasoning: 'Equal',
+    });
+
+    const tasks = [makeTaskComparison('task-1', 0.5, 0.5)];
+
+    // randomFn returns 0.9 → with-skill should be B
+    const result = await blindCompareAll(tasks, mockJudge, { randomFn: () => 0.9 });
+    expect(result.tasks[0].withSkillLabel).toBe('B');
+
+    // randomFn returns 0.1 → with-skill should be A
+    const result2 = await blindCompareAll(tasks, mockJudge, { randomFn: () => 0.1 });
+    expect(result2.tasks[0].withSkillLabel).toBe('A');
+  });
+
+  it('runs multiple tasks concurrently', async () => {
+    const callOrder: string[] = [];
+    const mockJudge = {
+      blindCompare: vi.fn().mockImplementation(async (_prompt: string, _a: string, _b: string) => {
+        callOrder.push('start');
+        // Simulate async work
+        await new Promise(r => setTimeout(r, 10));
+        callOrder.push('end');
+        return {
+          outputA: { instructionFollowing: 4, outputQuality: 4 },
+          outputB: { instructionFollowing: 3, outputQuality: 3 },
+          preferred: 'A' as const,
+          reasoning: 'A is better',
+        };
+      }),
+    } as unknown as SkillJudge;
+
+    const tasks = [
+      makeTaskComparison('task-1', 0.8, 0.3),
+      makeTaskComparison('task-2', 0.7, 0.4),
+      makeTaskComparison('task-3', 0.6, 0.5),
+    ];
+
+    const result = await blindCompareAll(tasks, mockJudge, { randomFn: () => 0.1 });
+
+    expect(result.tasks).toHaveLength(3);
+    expect(mockJudge.blindCompare).toHaveBeenCalledTimes(3);
+    // All 3 starts should happen before any ends (concurrent execution)
+    const starts = callOrder.filter(c => c === 'start');
+    const firstEnd = callOrder.indexOf('end');
+    expect(starts.length).toBe(3);
+    // With Promise.all, all starts happen before the first end
+    expect(callOrder.slice(0, 3)).toEqual(['start', 'start', 'start']);
   });
 });

--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  BlindTaskComparison,
+  BlindComparisonData,
+  TaskComparison,
+  TaskResult,
+  CombinedScore,
+} from '../types.js';
+
+/** Helper to create a minimal TaskResult */
+function makeResult(taskId: string, output = 'test output'): TaskResult {
+  return {
+    taskId,
+    prompt: 'test prompt',
+    output,
+    durationMs: 1000,
+    numTurns: 1,
+    costUsd: 0.01,
+    skillLoads: [],
+    toolCalls: [],
+    isError: false,
+    errorMessage: '',
+  };
+}
+
+/** Helper to create a minimal CombinedScore */
+function makeScore(
+  taskId: string,
+  overrides: Partial<CombinedScore> = {},
+): CombinedScore {
+  return {
+    taskId,
+    deterministic: null,
+    judge: null,
+    discovery: 1,
+    adherence: 4,
+    outputQuality: 4,
+    weightedScore: 0.8,
+    failureCategory: 'none',
+    reasoning: 'test',
+    ...overrides,
+  };
+}
+
+/** Helper to create a TaskComparison with a given weighted score delta */
+function makeTaskComparison(
+  taskId: string,
+  withSkillWeighted: number,
+  withoutSkillWeighted: number,
+): TaskComparison {
+  return {
+    taskId,
+    withSkill: {
+      result: makeResult(taskId, 'with-skill output'),
+      score: makeScore(taskId, { weightedScore: withSkillWeighted }),
+    },
+    withoutSkill: {
+      result: makeResult(taskId, 'without-skill output'),
+      score: makeScore(taskId, { weightedScore: withoutSkillWeighted }),
+    },
+    delta: {
+      taskId,
+      discoveryDelta: 0,
+      adherenceDelta: 0,
+      outputQualityDelta: 0,
+      weightedScoreDelta: withSkillWeighted - withoutSkillWeighted,
+      durationDeltaMs: 0,
+      costDeltaUsd: 0,
+    },
+  };
+}
+
+/** Helper to create a BlindTaskComparison */
+function makeBlindTask(
+  taskId: string,
+  preferredCondition: 'with-skill' | 'without-skill' | 'tie',
+  standardDelta: number,
+): BlindTaskComparison {
+  // Detect bias: standard prefers one, blind prefers the other
+  const standardPrefersWithSkill = standardDelta > 0.02;
+  const standardPrefersWithout = standardDelta < -0.02;
+  const biasSignal =
+    preferredCondition !== 'tie' &&
+    ((standardPrefersWithSkill && preferredCondition === 'without-skill') ||
+     (standardPrefersWithout && preferredCondition === 'with-skill'));
+
+  return {
+    taskId,
+    withSkillLabel: 'A',
+    outputA: { adherence: 4, outputQuality: 4 },
+    outputB: { adherence: 3, outputQuality: 3 },
+    preferred: preferredCondition === 'with-skill' ? 'A' : preferredCondition === 'without-skill' ? 'B' : 'tie',
+    reasoning: 'test reasoning',
+    preferredCondition,
+    biasSignal,
+  };
+}
+
+/** Helper to compute aggregate from tasks */
+function computeAggregate(tasks: BlindTaskComparison[]): BlindComparisonData['aggregate'] {
+  return {
+    withSkillPreferred: tasks.filter(t => t.preferredCondition === 'with-skill').length,
+    withoutSkillPreferred: tasks.filter(t => t.preferredCondition === 'without-skill').length,
+    ties: tasks.filter(t => t.preferredCondition === 'tie').length,
+    biasSignalCount: tasks.filter(t => t.biasSignal).length,
+  };
+}
+
+describe('Blind comparison bias detection', () => {
+  it('detects bias when standard prefers with-skill but blind prefers without-skill', () => {
+    // Standard delta = +0.2 (prefers with-skill), blind prefers without-skill
+    const task = makeBlindTask('task-1', 'without-skill', 0.2);
+    expect(task.biasSignal).toBe(true);
+  });
+
+  it('detects bias when standard prefers without-skill but blind prefers with-skill', () => {
+    // Standard delta = -0.2 (prefers without-skill), blind prefers with-skill
+    const task = makeBlindTask('task-1', 'with-skill', -0.2);
+    expect(task.biasSignal).toBe(true);
+  });
+
+  it('no bias when both agree on with-skill preference', () => {
+    // Standard delta = +0.2 (prefers with-skill), blind also prefers with-skill
+    const task = makeBlindTask('task-1', 'with-skill', 0.2);
+    expect(task.biasSignal).toBe(false);
+  });
+
+  it('no bias when both agree on without-skill preference', () => {
+    // Standard delta = -0.2, blind also prefers without-skill
+    const task = makeBlindTask('task-1', 'without-skill', -0.2);
+    expect(task.biasSignal).toBe(false);
+  });
+
+  it('no bias when blind result is a tie', () => {
+    const task = makeBlindTask('task-1', 'tie', 0.5);
+    expect(task.biasSignal).toBe(false);
+  });
+
+  it('no bias when standard delta is within threshold (neutral)', () => {
+    // Standard delta = 0.01, under 0.02 threshold
+    const task = makeBlindTask('task-1', 'without-skill', 0.01);
+    expect(task.biasSignal).toBe(false);
+  });
+});
+
+describe('Blind comparison label mapping', () => {
+  it('maps A preference to with-skill when withSkillLabel is A', () => {
+    const task: BlindTaskComparison = {
+      taskId: 'task-1',
+      withSkillLabel: 'A',
+      outputA: { adherence: 5, outputQuality: 5 },
+      outputB: { adherence: 3, outputQuality: 3 },
+      preferred: 'A',
+      reasoning: 'A is better',
+      preferredCondition: 'with-skill',
+      biasSignal: false,
+    };
+    expect(task.preferredCondition).toBe('with-skill');
+  });
+
+  it('maps B preference to with-skill when withSkillLabel is B', () => {
+    const task: BlindTaskComparison = {
+      taskId: 'task-1',
+      withSkillLabel: 'B',
+      outputA: { adherence: 3, outputQuality: 3 },
+      outputB: { adherence: 5, outputQuality: 5 },
+      preferred: 'B',
+      reasoning: 'B is better',
+      preferredCondition: 'with-skill',
+      biasSignal: false,
+    };
+    expect(task.preferredCondition).toBe('with-skill');
+  });
+
+  it('maps A preference to without-skill when withSkillLabel is B', () => {
+    const task: BlindTaskComparison = {
+      taskId: 'task-1',
+      withSkillLabel: 'B',
+      outputA: { adherence: 5, outputQuality: 5 },
+      outputB: { adherence: 3, outputQuality: 3 },
+      preferred: 'A',
+      reasoning: 'A is better',
+      preferredCondition: 'without-skill',
+      biasSignal: false,
+    };
+    expect(task.preferredCondition).toBe('without-skill');
+  });
+});
+
+describe('Blind comparison aggregate computation', () => {
+  it('computes correct aggregate counts', () => {
+    const tasks: BlindTaskComparison[] = [
+      makeBlindTask('task-1', 'with-skill', 0.1),
+      makeBlindTask('task-2', 'without-skill', 0.1),  // bias signal
+      makeBlindTask('task-3', 'tie', 0.1),
+      makeBlindTask('task-4', 'with-skill', 0.1),
+    ];
+
+    const aggregate = computeAggregate(tasks);
+
+    expect(aggregate.withSkillPreferred).toBe(2);
+    expect(aggregate.withoutSkillPreferred).toBe(1);
+    expect(aggregate.ties).toBe(1);
+    expect(aggregate.biasSignalCount).toBe(1);
+  });
+
+  it('handles all ties', () => {
+    const tasks: BlindTaskComparison[] = [
+      makeBlindTask('task-1', 'tie', 0.0),
+      makeBlindTask('task-2', 'tie', 0.0),
+    ];
+
+    const aggregate = computeAggregate(tasks);
+
+    expect(aggregate.withSkillPreferred).toBe(0);
+    expect(aggregate.withoutSkillPreferred).toBe(0);
+    expect(aggregate.ties).toBe(2);
+    expect(aggregate.biasSignalCount).toBe(0);
+  });
+
+  it('handles empty tasks array', () => {
+    const aggregate = computeAggregate([]);
+
+    expect(aggregate.withSkillPreferred).toBe(0);
+    expect(aggregate.withoutSkillPreferred).toBe(0);
+    expect(aggregate.ties).toBe(0);
+    expect(aggregate.biasSignalCount).toBe(0);
+  });
+});

--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -93,6 +93,7 @@ function makeBlindTask(
     reasoning: 'test reasoning',
     preferredCondition,
     biasSignal,
+    failed: false,
   };
 }
 
@@ -103,7 +104,7 @@ function computeAggregate(tasks: BlindTaskComparison[]): BlindComparisonData['ag
     withoutSkillPreferred: tasks.filter(t => t.preferredCondition === 'without-skill').length,
     ties: tasks.filter(t => t.preferredCondition === 'tie').length,
     biasSignalCount: tasks.filter(t => t.biasSignal).length,
-    failedCount: tasks.filter(t => t.reasoning === 'Blind judge call failed').length,
+    failedCount: tasks.filter(t => t.failed).length,
   };
 }
 
@@ -155,6 +156,7 @@ describe('Blind comparison label mapping', () => {
       reasoning: 'A is better',
       preferredCondition: 'with-skill',
       biasSignal: false,
+      failed: false,
     };
     expect(task.preferredCondition).toBe('with-skill');
   });
@@ -169,6 +171,7 @@ describe('Blind comparison label mapping', () => {
       reasoning: 'B is better',
       preferredCondition: 'with-skill',
       biasSignal: false,
+      failed: false,
     };
     expect(task.preferredCondition).toBe('with-skill');
   });
@@ -183,6 +186,7 @@ describe('Blind comparison label mapping', () => {
       reasoning: 'A is better',
       preferredCondition: 'without-skill',
       biasSignal: false,
+      failed: false,
     };
     expect(task.preferredCondition).toBe('without-skill');
   });

--- a/src/__tests__/github-summary.test.ts
+++ b/src/__tests__/github-summary.test.ts
@@ -84,8 +84,8 @@ describe('generateGitHubSummary', () => {
           {
             taskId: 'task-1',
             withSkillLabel: 'A',
-            outputA: { adherence: 5, outputQuality: 5 },
-            outputB: { adherence: 3, outputQuality: 3 },
+            outputA: { instructionFollowing: 5, outputQuality: 5 },
+            outputB: { instructionFollowing: 3, outputQuality: 3 },
             preferred: 'A',
             reasoning: 'A is better',
             preferredCondition: 'with-skill',
@@ -95,8 +95,8 @@ describe('generateGitHubSummary', () => {
           {
             taskId: 'task-2',
             withSkillLabel: 'B',
-            outputA: { adherence: 4, outputQuality: 4 },
-            outputB: { adherence: 4, outputQuality: 4 },
+            outputA: { instructionFollowing: 4, outputQuality: 4 },
+            outputB: { instructionFollowing: 4, outputQuality: 4 },
             preferred: 'tie',
             reasoning: 'Equal',
             preferredCondition: 'tie',

--- a/src/__tests__/github-summary.test.ts
+++ b/src/__tests__/github-summary.test.ts
@@ -90,6 +90,7 @@ describe('generateGitHubSummary', () => {
             reasoning: 'A is better',
             preferredCondition: 'with-skill',
             biasSignal: false,
+            failed: false,
           },
           {
             taskId: 'task-2',
@@ -100,6 +101,7 @@ describe('generateGitHubSummary', () => {
             reasoning: 'Equal',
             preferredCondition: 'tie',
             biasSignal: false,
+            failed: false,
           },
         ],
         aggregate: {

--- a/src/__tests__/github-summary.test.ts
+++ b/src/__tests__/github-summary.test.ts
@@ -77,6 +77,68 @@ describe('generateGitHubSummary', () => {
     expect(summary).not.toContain('Looks good');
   });
 
+  it('includes blind comparison section when present', () => {
+    const report = makeReport({
+      blindComparison: {
+        tasks: [
+          {
+            taskId: 'task-1',
+            withSkillLabel: 'A',
+            outputA: { adherence: 5, outputQuality: 5 },
+            outputB: { adherence: 3, outputQuality: 3 },
+            preferred: 'A',
+            reasoning: 'A is better',
+            preferredCondition: 'with-skill',
+            biasSignal: false,
+          },
+          {
+            taskId: 'task-2',
+            withSkillLabel: 'B',
+            outputA: { adherence: 4, outputQuality: 4 },
+            outputB: { adherence: 4, outputQuality: 4 },
+            preferred: 'tie',
+            reasoning: 'Equal',
+            preferredCondition: 'tie',
+            biasSignal: false,
+          },
+        ],
+        aggregate: {
+          withSkillPreferred: 1,
+          withoutSkillPreferred: 0,
+          ties: 1,
+          biasSignalCount: 0,
+        },
+      },
+    });
+
+    const summary = generateGitHubSummary(report);
+
+    expect(summary).toContain('### Blind A/B Comparison');
+    expect(summary).toContain('| With-skill | 1 | 50% |');
+    expect(summary).toContain('| Without-skill | 0 | 0% |');
+    expect(summary).toContain('| Tie | 1 | 50% |');
+    // No bias signals, so no warning
+    expect(summary).not.toContain('bias signal');
+  });
+
+  it('shows bias warning in blind comparison when bias signals exist', () => {
+    const report = makeReport({
+      blindComparison: {
+        tasks: [],
+        aggregate: {
+          withSkillPreferred: 0,
+          withoutSkillPreferred: 1,
+          ties: 0,
+          biasSignalCount: 1,
+        },
+      },
+    });
+
+    const summary = generateGitHubSummary(report);
+
+    expect(summary).toContain(':warning: **1 bias signal(s):**');
+  });
+
   it('handles checklist items with no evidence', () => {
     const report = makeReport({
       tasks: [

--- a/src/__tests__/github-summary.test.ts
+++ b/src/__tests__/github-summary.test.ts
@@ -107,6 +107,7 @@ describe('generateGitHubSummary', () => {
           withoutSkillPreferred: 0,
           ties: 1,
           biasSignalCount: 0,
+          failedCount: 0,
         },
       },
     });
@@ -130,6 +131,7 @@ describe('generateGitHubSummary', () => {
           withoutSkillPreferred: 1,
           ties: 0,
           biasSignalCount: 1,
+          failedCount: 0,
         },
       },
     });

--- a/src/__tests__/judge.test.ts
+++ b/src/__tests__/judge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractJsonObject, parseJudgeResponseJson } from '../scorer/judge.js';
+import { extractJsonObject, parseJudgeResponseJson, parseBlindJudgeResponse } from '../scorer/judge.js';
 
 describe('extractJsonObject', () => {
   it('extracts a simple JSON object', () => {
@@ -293,5 +293,109 @@ describe('parseJudgeResponseJson', () => {
     expect(score.discovery).toBe(0);
     expect(score.adherence).toBe(2);
     expect(score.failureCategory).toBe('discovery_failure');
+  });
+});
+
+describe('parseBlindJudgeResponse', () => {
+  it('parses a valid response', () => {
+    const response = JSON.stringify({
+      output_a: { adherence: 4, output_quality: 5 },
+      output_b: { adherence: 3, output_quality: 2 },
+      preferred: 'A',
+      reasoning: 'Output A is better',
+    });
+    const result = parseBlindJudgeResponse(response);
+
+    expect(result).not.toBeNull();
+    expect(result!.outputA.adherence).toBe(4);
+    expect(result!.outputA.outputQuality).toBe(5);
+    expect(result!.outputB.adherence).toBe(3);
+    expect(result!.outputB.outputQuality).toBe(2);
+    expect(result!.preferred).toBe('A');
+    expect(result!.reasoning).toBe('Output A is better');
+  });
+
+  it('parses response wrapped in markdown code block', () => {
+    const json = JSON.stringify({
+      output_a: { adherence: 5, output_quality: 5 },
+      output_b: { adherence: 4, output_quality: 4 },
+      preferred: 'A',
+      reasoning: 'Better quality',
+    });
+    const response = `\`\`\`json\n${json}\n\`\`\``;
+    const result = parseBlindJudgeResponse(response);
+
+    expect(result).not.toBeNull();
+    expect(result!.outputA.adherence).toBe(5);
+    expect(result!.preferred).toBe('A');
+  });
+
+  it('returns null on unparseable input', () => {
+    expect(parseBlindJudgeResponse('no json here')).toBeNull();
+    expect(parseBlindJudgeResponse('')).toBeNull();
+  });
+
+  it('clamps scores to 1-5', () => {
+    const response = JSON.stringify({
+      output_a: { adherence: 0, output_quality: 7 },
+      output_b: { adherence: -1, output_quality: 10 },
+      preferred: 'B',
+      reasoning: 'Test clamping',
+    });
+    const result = parseBlindJudgeResponse(response);
+
+    expect(result).not.toBeNull();
+    expect(result!.outputA.adherence).toBe(1);
+    expect(result!.outputA.outputQuality).toBe(5);
+    expect(result!.outputB.adherence).toBe(1);
+    expect(result!.outputB.outputQuality).toBe(5);
+  });
+
+  it('normalizes preferred to uppercase, fallback to tie', () => {
+    const makeResponse = (pref: string) => JSON.stringify({
+      output_a: { adherence: 3, output_quality: 3 },
+      output_b: { adherence: 3, output_quality: 3 },
+      preferred: pref,
+      reasoning: 'test',
+    });
+
+    expect(parseBlindJudgeResponse(makeResponse('a'))!.preferred).toBe('A');
+    expect(parseBlindJudgeResponse(makeResponse('b'))!.preferred).toBe('B');
+    expect(parseBlindJudgeResponse(makeResponse('TIE'))!.preferred).toBe('tie');
+    expect(parseBlindJudgeResponse(makeResponse('neither'))!.preferred).toBe('tie');
+    expect(parseBlindJudgeResponse(makeResponse(''))!.preferred).toBe('tie');
+  });
+
+  it('returns null when output_a or output_b is missing', () => {
+    const noA = JSON.stringify({
+      output_b: { adherence: 3, output_quality: 3 },
+      preferred: 'B',
+      reasoning: 'missing a',
+    });
+    expect(parseBlindJudgeResponse(noA)).toBeNull();
+
+    const noB = JSON.stringify({
+      output_a: { adherence: 3, output_quality: 3 },
+      preferred: 'A',
+      reasoning: 'missing b',
+    });
+    expect(parseBlindJudgeResponse(noB)).toBeNull();
+  });
+
+  it('defaults missing fields gracefully', () => {
+    const response = JSON.stringify({
+      output_a: { adherence: 4 },
+      output_b: { output_quality: 3 },
+      preferred: 'A',
+    });
+    const result = parseBlindJudgeResponse(response);
+
+    expect(result).not.toBeNull();
+    // Missing output_quality defaults to 1 (NaN clamp)
+    expect(result!.outputA.outputQuality).toBe(1);
+    // Missing adherence defaults to 1 (NaN clamp)
+    expect(result!.outputB.adherence).toBe(1);
+    // Missing reasoning defaults to empty string
+    expect(result!.reasoning).toBe('');
   });
 });

--- a/src/__tests__/judge.test.ts
+++ b/src/__tests__/judge.test.ts
@@ -299,17 +299,17 @@ describe('parseJudgeResponseJson', () => {
 describe('parseBlindJudgeResponse', () => {
   it('parses a valid response', () => {
     const response = JSON.stringify({
-      output_a: { adherence: 4, output_quality: 5 },
-      output_b: { adherence: 3, output_quality: 2 },
+      output_a: { instruction_following: 4, output_quality: 5 },
+      output_b: { instruction_following: 3, output_quality: 2 },
       preferred: 'A',
       reasoning: 'Output A is better',
     });
     const result = parseBlindJudgeResponse(response);
 
     expect(result).not.toBeNull();
-    expect(result!.outputA.adherence).toBe(4);
+    expect(result!.outputA.instructionFollowing).toBe(4);
     expect(result!.outputA.outputQuality).toBe(5);
-    expect(result!.outputB.adherence).toBe(3);
+    expect(result!.outputB.instructionFollowing).toBe(3);
     expect(result!.outputB.outputQuality).toBe(2);
     expect(result!.preferred).toBe('A');
     expect(result!.reasoning).toBe('Output A is better');
@@ -317,8 +317,8 @@ describe('parseBlindJudgeResponse', () => {
 
   it('parses response wrapped in markdown code block', () => {
     const json = JSON.stringify({
-      output_a: { adherence: 5, output_quality: 5 },
-      output_b: { adherence: 4, output_quality: 4 },
+      output_a: { instruction_following: 5, output_quality: 5 },
+      output_b: { instruction_following: 4, output_quality: 4 },
       preferred: 'A',
       reasoning: 'Better quality',
     });
@@ -326,7 +326,7 @@ describe('parseBlindJudgeResponse', () => {
     const result = parseBlindJudgeResponse(response);
 
     expect(result).not.toBeNull();
-    expect(result!.outputA.adherence).toBe(5);
+    expect(result!.outputA.instructionFollowing).toBe(5);
     expect(result!.preferred).toBe('A');
   });
 
@@ -337,24 +337,24 @@ describe('parseBlindJudgeResponse', () => {
 
   it('clamps scores to 1-5', () => {
     const response = JSON.stringify({
-      output_a: { adherence: 0, output_quality: 7 },
-      output_b: { adherence: -1, output_quality: 10 },
+      output_a: { instruction_following: 0, output_quality: 7 },
+      output_b: { instruction_following: -1, output_quality: 10 },
       preferred: 'B',
       reasoning: 'Test clamping',
     });
     const result = parseBlindJudgeResponse(response);
 
     expect(result).not.toBeNull();
-    expect(result!.outputA.adherence).toBe(1);
+    expect(result!.outputA.instructionFollowing).toBe(1);
     expect(result!.outputA.outputQuality).toBe(5);
-    expect(result!.outputB.adherence).toBe(1);
+    expect(result!.outputB.instructionFollowing).toBe(1);
     expect(result!.outputB.outputQuality).toBe(5);
   });
 
   it('normalizes preferred to uppercase, fallback to tie', () => {
     const makeResponse = (pref: string) => JSON.stringify({
-      output_a: { adherence: 3, output_quality: 3 },
-      output_b: { adherence: 3, output_quality: 3 },
+      output_a: { instruction_following: 3, output_quality: 3 },
+      output_b: { instruction_following: 3, output_quality: 3 },
       preferred: pref,
       reasoning: 'test',
     });
@@ -368,14 +368,14 @@ describe('parseBlindJudgeResponse', () => {
 
   it('returns null when output_a or output_b is missing', () => {
     const noA = JSON.stringify({
-      output_b: { adherence: 3, output_quality: 3 },
+      output_b: { instruction_following: 3, output_quality: 3 },
       preferred: 'B',
       reasoning: 'missing a',
     });
     expect(parseBlindJudgeResponse(noA)).toBeNull();
 
     const noB = JSON.stringify({
-      output_a: { adherence: 3, output_quality: 3 },
+      output_a: { instruction_following: 3, output_quality: 3 },
       preferred: 'A',
       reasoning: 'missing b',
     });
@@ -384,7 +384,7 @@ describe('parseBlindJudgeResponse', () => {
 
   it('defaults missing fields gracefully', () => {
     const response = JSON.stringify({
-      output_a: { adherence: 4 },
+      output_a: { instruction_following: 4 },
       output_b: { output_quality: 3 },
       preferred: 'A',
     });
@@ -393,8 +393,8 @@ describe('parseBlindJudgeResponse', () => {
     expect(result).not.toBeNull();
     // Missing output_quality defaults to 1 (NaN clamp)
     expect(result!.outputA.outputQuality).toBe(1);
-    // Missing adherence defaults to 1 (NaN clamp)
-    expect(result!.outputB.adherence).toBe(1);
+    // Missing instruction_following defaults to 1 (NaN clamp)
+    expect(result!.outputB.instructionFollowing).toBe(1);
     // Missing reasoning defaults to empty string
     expect(result!.reasoning).toBe('');
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,7 @@ program
   .option('--verbose', 'Enable verbose output')
   .option('--compare', 'Run with and without skill to measure skill impact')
   .option('--compare-skill <path>', 'Path to baseline skill directory (e.g., previous version) for A/B comparison')
+  .option('--blind-compare', 'Run blind A/B comparison alongside --compare')
   .action(async (tasksFile: string, options: {
     runner?: string;
     model?: string;
@@ -78,6 +79,7 @@ program
     verbose?: boolean;
     compare?: boolean;
     compareSkill?: string;
+    blindCompare?: boolean;
   }) => {
     try {
       if (options.runner && !VALID_RUNNER_TYPES.includes(options.runner as RunnerType)) {
@@ -111,6 +113,7 @@ program
         verbose: options.verbose,
         compare: options.compare || !!options.compareSkill,
         compareSkillPath: options.compareSkill,
+        blindCompare: options.blindCompare,
       });
 
       if (!result.passed) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export { createToolPolicy } from './runner/security.js';
 // Scorer
 export { scoreTask, scoreAll } from './scorer/scorer.js';
 export { scoreDeterministic } from './scorer/deterministic.js';
-export { SkillJudge, parseBlindJudgeResponse, blindCompareAll } from './scorer/judge.js';
+export { SkillJudge, parseBlindJudgeResponse, blindCompareAll, BLIND_BIAS_THRESHOLD } from './scorer/judge.js';
 export { aggregateResults, aggregateScores, computeStddev, FLAKY_STDDEV_THRESHOLD } from './scorer/aggregator.js';
 
 // Session
@@ -74,7 +74,7 @@ export { generateReport, generateJsonResults, computeSummary, computeFailureBrea
 export type { ReportOptions } from './report/report.js';
 export { generateGitHubSummary, writeGitHubSummary } from './report/github-summary.js';
 export { loadPreviousReport, compareResults, formatComparisonMarkdown, formatComparisonConsole } from './report/comparison.js';
-export { formatDelta, formatCategory } from './utils/format.js';
+export { formatDelta, formatCategory, pct } from './utils/format.js';
 
 // Feedback
 export { generateFeedbackTemplate, writeFeedbackTemplate, loadFeedback, validateFeedback, getFeedbackForTask } from './feedback.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export { createToolPolicy } from './runner/security.js';
 // Scorer
 export { scoreTask, scoreAll } from './scorer/scorer.js';
 export { scoreDeterministic } from './scorer/deterministic.js';
-export { SkillJudge, parseBlindJudgeResponse, blindCompareAll, mapPreferredToCondition, BLIND_BIAS_THRESHOLD, DEFAULT_CONCURRENCY } from './scorer/judge.js';
+export { SkillJudge, blindCompareAll, BLIND_BIAS_THRESHOLD, DEFAULT_CONCURRENCY } from './scorer/judge.js';
 export type { BlindCompareOptions } from './scorer/judge.js';
 export { aggregateResults, aggregateScores, computeStddev, FLAKY_STDDEV_THRESHOLD } from './scorer/aggregator.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,9 @@ export type {
   TaskDelta,
   SummaryDelta,
   ComparisonResult,
+  BlindOutputScore,
+  BlindTaskComparison,
+  BlindComparisonData,
 } from './types.js';
 
 // Config
@@ -60,7 +63,7 @@ export { createToolPolicy } from './runner/security.js';
 // Scorer
 export { scoreTask, scoreAll } from './scorer/scorer.js';
 export { scoreDeterministic } from './scorer/deterministic.js';
-export { SkillJudge } from './scorer/judge.js';
+export { SkillJudge, parseBlindJudgeResponse, blindCompareAll } from './scorer/judge.js';
 export { aggregateResults, aggregateScores, computeStddev, FLAKY_STDDEV_THRESHOLD } from './scorer/aggregator.js';
 
 // Session

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export { createToolPolicy } from './runner/security.js';
 // Scorer
 export { scoreTask, scoreAll } from './scorer/scorer.js';
 export { scoreDeterministic } from './scorer/deterministic.js';
-export { SkillJudge, parseBlindJudgeResponse, blindCompareAll, BLIND_BIAS_THRESHOLD } from './scorer/judge.js';
+export { SkillJudge, parseBlindJudgeResponse, blindCompareAll, mapPreferredToCondition, BLIND_BIAS_THRESHOLD, DEFAULT_CONCURRENCY } from './scorer/judge.js';
 export type { BlindCompareOptions } from './scorer/judge.js';
 export { aggregateResults, aggregateScores, computeStddev, FLAKY_STDDEV_THRESHOLD } from './scorer/aggregator.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export { createToolPolicy } from './runner/security.js';
 export { scoreTask, scoreAll } from './scorer/scorer.js';
 export { scoreDeterministic } from './scorer/deterministic.js';
 export { SkillJudge, parseBlindJudgeResponse, blindCompareAll, BLIND_BIAS_THRESHOLD } from './scorer/judge.js';
+export type { BlindCompareOptions } from './scorer/judge.js';
 export { aggregateResults, aggregateScores, computeStddev, FLAKY_STDDEV_THRESHOLD } from './scorer/aggregator.js';
 
 // Session

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -619,18 +619,18 @@ function printComparisonSummary(comparison: ComparisonData): void {
 
 function printBlindComparisonSummary(blind: BlindComparisonData): void {
   const a = blind.aggregate;
-  const total = blind.tasks.length;
+  const evaluated = blind.tasks.length - a.failedCount;
   console.log('\n' + '-'.repeat(50));
   console.log('  Blind A/B Comparison');
   console.log('-'.repeat(50));
-  console.log(`  With-skill preferred: ${a.withSkillPreferred}/${total} (${pct(a.withSkillPreferred, total)}%)`);
-  console.log(`  Without-skill preferred: ${a.withoutSkillPreferred}/${total} (${pct(a.withoutSkillPreferred, total)}%)`);
-  console.log(`  Ties: ${a.ties}/${total}`);
+  console.log(`  With-skill preferred: ${a.withSkillPreferred}/${evaluated} (${pct(a.withSkillPreferred, evaluated)}%)`);
+  console.log(`  Without-skill preferred: ${a.withoutSkillPreferred}/${evaluated} (${pct(a.withoutSkillPreferred, evaluated)}%)`);
+  console.log(`  Ties: ${a.ties}/${evaluated}`);
   if (a.biasSignalCount > 0) {
     console.log(`  Bias signals: ${a.biasSignalCount} (blind disagrees with standard scoring)`);
   }
   if (a.failedCount > 0) {
-    console.log(`  Failed: ${a.failedCount} blind judge call(s) failed (recorded as ties)`);
+    console.log(`  Failed: ${a.failedCount} blind judge call(s) failed (excluded from counts)`);
   }
   console.log('-'.repeat(50));
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -34,8 +34,10 @@ import type {
   ComparisonData,
   ComparisonSummary,
   TaskComparison,
+  BlindComparisonData,
 } from './types.js';
 import { loadFeedback, writeFeedbackTemplate } from './feedback.js';
+import { SkillJudge, blindCompareAll } from './scorer/judge.js';
 
 /**
  * Load human feedback from a file, validating against known task IDs.
@@ -87,6 +89,8 @@ export interface PipelineOptions {
   compare?: boolean;
   /** Path to alternative skill for comparison (instead of no-skill baseline) */
   compareSkillPath?: string;
+  /** Run blind A/B comparison alongside --compare */
+  blindCompare?: boolean;
 }
 
 export interface PipelineResult {
@@ -101,6 +105,7 @@ export interface PipelineResult {
   markdownSummary: string;
   feedbackTemplatePath?: string;
   comparison?: ComparisonData;
+  blindComparison?: BlindComparisonData;
   crossIterationComparison?: ComparisonResult;
 }
 
@@ -263,6 +268,10 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   const cwd = options.cwd || process.cwd();
   const compareMode = options.compare || !!options.compareSkillPath;
 
+  if (options.blindCompare && !compareMode) {
+    throw new Error('--blind-compare requires --compare mode');
+  }
+
   // 1. Parse tasks
   console.log(`Parsing tasks from: ${options.tasksFile}`);
   let evaluation = await parseEvalFile(options.tasksFile);
@@ -348,6 +357,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   // 3. Run evaluation phase(s)
   let primaryPhase: PhaseResult;
   let comparison: ComparisonData | undefined;
+  let blindComparison: BlindComparisonData | undefined;
   let crossIterationComparison: ComparisonResult | undefined;
 
   let needsCleanup = false;
@@ -396,6 +406,13 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
 
       console.log('\n=== Computing Comparison Deltas ===\n');
       comparison = computeComparison(withPhase, basePhase, baselineLabel, options.compareSkillPath);
+
+      if (options.blindCompare) {
+        console.log('\n=== Running Blind A/B Comparison ===\n');
+        const blindJudge = new SkillJudge({ model: config.defaultJudgeModel });
+        blindComparison = await blindCompareAll(comparison.tasks, blindJudge);
+      }
+
       primaryPhase = withPhase;
     } else {
       // --- Normal mode: single phase ---
@@ -451,6 +468,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
     numRuns,
     runDetails: primaryPhase.runDetails,
     comparison,
+    blindComparison,
     crossIterationComparison,
   };
 
@@ -470,6 +488,9 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   if (comparison) {
     printComparisonSummary(comparison);
   }
+  if (blindComparison) {
+    printBlindComparisonSummary(blindComparison);
+  }
   if (crossIterationComparison) {
     console.log(formatComparisonConsole(crossIterationComparison));
   }
@@ -485,6 +506,7 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
     jsonPath,
     markdownSummary,
     comparison,
+    blindComparison,
     crossIterationComparison,
   };
 }
@@ -592,6 +614,21 @@ function printComparisonSummary(comparison: ComparisonData): void {
   console.log(`  Weighted Score Delta: ${formatDelta(d.avgWeightedScoreDelta, 2)}`);
   console.log(`  Duration Delta: ${formatDelta(d.totalDurationDeltaMs / 1000, 1)}s`);
   console.log(`  Cost Delta: $${formatDelta(d.totalCostDeltaUsd, 4)}`);
+  console.log('-'.repeat(50));
+}
+
+function printBlindComparisonSummary(blind: BlindComparisonData): void {
+  const a = blind.aggregate;
+  const total = blind.tasks.length;
+  console.log('\n' + '-'.repeat(50));
+  console.log('  Blind A/B Comparison');
+  console.log('-'.repeat(50));
+  console.log(`  With-skill preferred: ${a.withSkillPreferred}/${total} (${total > 0 ? ((a.withSkillPreferred / total) * 100).toFixed(0) : 0}%)`);
+  console.log(`  Without-skill preferred: ${a.withoutSkillPreferred}/${total} (${total > 0 ? ((a.withoutSkillPreferred / total) * 100).toFixed(0) : 0}%)`);
+  console.log(`  Ties: ${a.ties}/${total}`);
+  if (a.biasSignalCount > 0) {
+    console.log(`  Bias signals: ${a.biasSignalCount} (blind disagrees with standard scoring)`);
+  }
   console.log('-'.repeat(50));
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -629,6 +629,9 @@ function printBlindComparisonSummary(blind: BlindComparisonData): void {
   if (a.biasSignalCount > 0) {
     console.log(`  Bias signals: ${a.biasSignalCount} (blind disagrees with standard scoring)`);
   }
+  if (a.failedCount > 0) {
+    console.log(`  Failed: ${a.failedCount} blind judge call(s) failed (recorded as ties)`);
+  }
   console.log('-'.repeat(50));
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -10,7 +10,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { formatDelta } from './utils/format.js';
+import { formatDelta, pct } from './utils/format.js';
 import { parseEvalFile } from './parser.js';
 import { setupLocalSkills, cleanupLocalSkills } from './runner/skill-setup.js';
 import { createRunner } from './runner/runner-factory.js';
@@ -623,8 +623,8 @@ function printBlindComparisonSummary(blind: BlindComparisonData): void {
   console.log('\n' + '-'.repeat(50));
   console.log('  Blind A/B Comparison');
   console.log('-'.repeat(50));
-  console.log(`  With-skill preferred: ${a.withSkillPreferred}/${total} (${total > 0 ? ((a.withSkillPreferred / total) * 100).toFixed(0) : 0}%)`);
-  console.log(`  Without-skill preferred: ${a.withoutSkillPreferred}/${total} (${total > 0 ? ((a.withoutSkillPreferred / total) * 100).toFixed(0) : 0}%)`);
+  console.log(`  With-skill preferred: ${a.withSkillPreferred}/${total} (${pct(a.withSkillPreferred, total)}%)`);
+  console.log(`  Without-skill preferred: ${a.withoutSkillPreferred}/${total} (${pct(a.withoutSkillPreferred, total)}%)`);
   console.log(`  Ties: ${a.ties}/${total}`);
   if (a.biasSignalCount > 0) {
     console.log(`  Bias signals: ${a.biasSignalCount} (blind disagrees with standard scoring)`);

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -5,7 +5,7 @@
  */
 
 import * as fs from 'fs/promises';
-import { formatDelta, formatCategory } from '../utils/format.js';
+import { formatDelta, formatCategory, pct } from '../utils/format.js';
 import type {
   EvaluationReport,
   EvaluationSummary,
@@ -145,9 +145,9 @@ export function generateGitHubSummary(report: EvaluationReport): string {
     lines.push('');
     lines.push('| Preference | Count | % |');
     lines.push('|------------|-------|---|');
-    lines.push(`| With-skill | ${ba.withSkillPreferred} | ${total > 0 ? ((ba.withSkillPreferred / total) * 100).toFixed(0) : 0}% |`);
-    lines.push(`| Without-skill | ${ba.withoutSkillPreferred} | ${total > 0 ? ((ba.withoutSkillPreferred / total) * 100).toFixed(0) : 0}% |`);
-    lines.push(`| Tie | ${ba.ties} | ${total > 0 ? ((ba.ties / total) * 100).toFixed(0) : 0}% |`);
+    lines.push(`| With-skill | ${ba.withSkillPreferred} | ${pct(ba.withSkillPreferred, total)}% |`);
+    lines.push(`| Without-skill | ${ba.withoutSkillPreferred} | ${pct(ba.withoutSkillPreferred, total)}% |`);
+    lines.push(`| Tie | ${ba.ties} | ${pct(ba.ties, total)}% |`);
     lines.push('');
     if (ba.biasSignalCount > 0) {
       lines.push(`:warning: **${ba.biasSignalCount} bias signal(s):** blind comparison disagrees with standard scoring`);

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -153,6 +153,10 @@ export function generateGitHubSummary(report: EvaluationReport): string {
       lines.push(`:warning: **${ba.biasSignalCount} bias signal(s):** blind comparison disagrees with standard scoring`);
       lines.push('');
     }
+    if (ba.failedCount > 0) {
+      lines.push(`:warning: **${ba.failedCount} blind judge call(s) failed** — recorded as ties with neutral scores`);
+      lines.push('');
+    }
   }
 
   // Comparison section

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -137,6 +137,24 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   lines.push('</details>');
   lines.push('');
 
+  // Blind comparison section
+  if (report.blindComparison) {
+    const ba = report.blindComparison.aggregate;
+    const total = report.blindComparison.tasks.length;
+    lines.push('### Blind A/B Comparison');
+    lines.push('');
+    lines.push('| Preference | Count | % |');
+    lines.push('|------------|-------|---|');
+    lines.push(`| With-skill | ${ba.withSkillPreferred} | ${total > 0 ? ((ba.withSkillPreferred / total) * 100).toFixed(0) : 0}% |`);
+    lines.push(`| Without-skill | ${ba.withoutSkillPreferred} | ${total > 0 ? ((ba.withoutSkillPreferred / total) * 100).toFixed(0) : 0}% |`);
+    lines.push(`| Tie | ${ba.ties} | ${total > 0 ? ((ba.ties / total) * 100).toFixed(0) : 0}% |`);
+    lines.push('');
+    if (ba.biasSignalCount > 0) {
+      lines.push(`:warning: **${ba.biasSignalCount} bias signal(s):** blind comparison disagrees with standard scoring`);
+      lines.push('');
+    }
+  }
+
   // Comparison section
   if (report.comparison) {
     const d = report.comparison.summary.delta;

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -156,21 +156,21 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   // Blind comparison section (cross-validation, shown after primary comparison)
   if (report.blindComparison) {
     const ba = report.blindComparison.aggregate;
-    const total = report.blindComparison.tasks.length;
+    const evaluated = report.blindComparison.tasks.length - ba.failedCount;
     lines.push('### Blind A/B Comparison');
     lines.push('');
     lines.push('| Preference | Count | % |');
     lines.push('|------------|-------|---|');
-    lines.push(`| With-skill | ${ba.withSkillPreferred} | ${pct(ba.withSkillPreferred, total)}% |`);
-    lines.push(`| Without-skill | ${ba.withoutSkillPreferred} | ${pct(ba.withoutSkillPreferred, total)}% |`);
-    lines.push(`| Tie | ${ba.ties} | ${pct(ba.ties, total)}% |`);
+    lines.push(`| With-skill | ${ba.withSkillPreferred} | ${pct(ba.withSkillPreferred, evaluated)}% |`);
+    lines.push(`| Without-skill | ${ba.withoutSkillPreferred} | ${pct(ba.withoutSkillPreferred, evaluated)}% |`);
+    lines.push(`| Tie | ${ba.ties} | ${pct(ba.ties, evaluated)}% |`);
     lines.push('');
     if (ba.biasSignalCount > 0) {
       lines.push(`:warning: **${ba.biasSignalCount} bias signal(s):** blind comparison disagrees with standard scoring`);
       lines.push('');
     }
     if (ba.failedCount > 0) {
-      lines.push(`:warning: **${ba.failedCount} blind judge call(s) failed** — recorded as ties with neutral scores`);
+      lines.push(`:warning: **${ba.failedCount} blind judge call(s) failed** — excluded from preference counts`);
       lines.push('');
     }
   }

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -137,7 +137,23 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   lines.push('</details>');
   lines.push('');
 
-  // Blind comparison section
+  // Comparison section (primary data first)
+  if (report.comparison) {
+    const d = report.comparison.summary.delta;
+    const ws = report.comparison.summary.withSkill;
+    const bs = report.comparison.summary.withoutSkill;
+    lines.push(`### Skill Impact (vs ${report.comparison.summary.baselineLabel})`);
+    lines.push('');
+    lines.push('| Metric | With Skill | Baseline | Delta |');
+    lines.push('|--------|-----------|----------|-------|');
+    lines.push(`| Discovery | ${(ws.discoveryAccuracy * 100).toFixed(0)}% | ${(bs.discoveryAccuracy * 100).toFixed(0)}% | **${formatDelta(d.discoveryAccuracyDelta * 100, 0)}%** |`);
+    lines.push(`| Adherence | ${ws.avgAdherence.toFixed(1)}/5 | ${bs.avgAdherence.toFixed(1)}/5 | **${formatDelta(d.avgAdherenceDelta)}** |`);
+    lines.push(`| Output Quality | ${ws.avgOutputQuality.toFixed(1)}/5 | ${bs.avgOutputQuality.toFixed(1)}/5 | **${formatDelta(d.avgOutputQualityDelta)}** |`);
+    lines.push(`| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | **${formatDelta(d.avgWeightedScoreDelta)}** |`);
+    lines.push('');
+  }
+
+  // Blind comparison section (cross-validation, shown after primary comparison)
   if (report.blindComparison) {
     const ba = report.blindComparison.aggregate;
     const total = report.blindComparison.tasks.length;
@@ -157,22 +173,6 @@ export function generateGitHubSummary(report: EvaluationReport): string {
       lines.push(`:warning: **${ba.failedCount} blind judge call(s) failed** — recorded as ties with neutral scores`);
       lines.push('');
     }
-  }
-
-  // Comparison section
-  if (report.comparison) {
-    const d = report.comparison.summary.delta;
-    const ws = report.comparison.summary.withSkill;
-    const bs = report.comparison.summary.withoutSkill;
-    lines.push(`### Skill Impact (vs ${report.comparison.summary.baselineLabel})`);
-    lines.push('');
-    lines.push('| Metric | With Skill | Baseline | Delta |');
-    lines.push('|--------|-----------|----------|-------|');
-    lines.push(`| Discovery | ${(ws.discoveryAccuracy * 100).toFixed(0)}% | ${(bs.discoveryAccuracy * 100).toFixed(0)}% | **${formatDelta(d.discoveryAccuracyDelta * 100, 0)}%** |`);
-    lines.push(`| Adherence | ${ws.avgAdherence.toFixed(1)}/5 | ${bs.avgAdherence.toFixed(1)}/5 | **${formatDelta(d.avgAdherenceDelta)}** |`);
-    lines.push(`| Output Quality | ${ws.avgOutputQuality.toFixed(1)}/5 | ${bs.avgOutputQuality.toFixed(1)}/5 | **${formatDelta(d.avgOutputQualityDelta)}** |`);
-    lines.push(`| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | **${formatDelta(d.avgWeightedScoreDelta)}** |`);
-    lines.push('');
   }
 
   if (!report.passed && report.failureReasons.length > 0) {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -468,6 +468,7 @@ function generateBlindComparisonSection(blind: BlindComparisonData): string {
 ## Blind A/B Comparison
 
 The judge evaluated both outputs without knowing which used the skill.
+Assignment shows the label order: with-skill / without-skill (e.g. A/B means A = with-skill, B = without-skill).
 
 | Preference | Count | Percentage |
 |------------|-------|------------|

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -490,5 +490,9 @@ The judge evaluated both outputs without knowing which used the skill.
     section += `\n> **Bias Alert:** ${a.biasSignalCount} task(s) show bias signals where the blind comparison disagrees with standard scoring. This may indicate the standard judge is biased by knowing which output used the skill.\n`;
   }
 
+  if (a.failedCount > 0) {
+    section += `\n> **Warning:** ${a.failedCount} blind judge call(s) failed and were recorded as ties with neutral scores.\n`;
+  }
+
   return section;
 }

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -478,13 +478,13 @@ Assignment shows the label order: with-skill / without-skill (e.g. A/B means A =
 
 ### Per-Task Blind Results
 
-| Task | Assignment | A Adherence | A Output | B Adherence | B Output | Preferred | Condition | Bias? |
-|------|------------|-------------|----------|-------------|----------|-----------|-----------|-------|
+| Task | Assignment | A Instr. Following | A Output | B Instr. Following | B Output | Preferred | Condition | Bias? |
+|------|------------|---------------------|----------|---------------------|----------|-----------|-----------|-------|
 `;
 
   for (const t of blind.tasks) {
     const labels = t.withSkillLabel === 'A' ? 'A/B' : 'B/A';
-    section += `| ${t.taskId} | ${labels} | ${t.outputA.adherence}/5 | ${t.outputA.outputQuality}/5 | ${t.outputB.adherence}/5 | ${t.outputB.outputQuality}/5 | ${t.preferred} | ${t.preferredCondition} | ${t.biasSignal ? 'Yes' : 'No'} |\n`;
+    section += `| ${t.taskId} | ${labels} | ${t.outputA.instructionFollowing}/5 | ${t.outputA.outputQuality}/5 | ${t.outputB.instructionFollowing}/5 | ${t.outputB.outputQuality}/5 | ${t.preferred} | ${t.preferredCondition} | ${t.biasSignal ? 'Yes' : 'No'} |\n`;
   }
 
   if (a.biasSignalCount > 0) {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -19,6 +19,7 @@ import type {
   ReportMetadata,
   HumanFeedback,
   ComparisonData,
+  BlindComparisonData,
 } from '../types.js';
 import { loadConfigSync } from '../config.js';
 import { FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
@@ -34,6 +35,7 @@ export interface ReportOptions {
   runDetails?: Array<{ result: TaskResult; score: CombinedScore }>[];
   humanFeedback?: HumanFeedback;
   comparison?: ComparisonData;
+  blindComparison?: BlindComparisonData;
   crossIterationComparison?: ComparisonResult;
 }
 
@@ -41,7 +43,7 @@ export interface ReportOptions {
  * Generate a markdown report from evaluation results.
  */
 export async function generateReport(options: ReportOptions): Promise<string> {
-  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison, crossIterationComparison } = options;
+  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison, blindComparison, crossIterationComparison } = options;
   const numRuns = options.numRuns ?? 1;
   const config = loadConfigSync();
   const totalTasks = evaluation.tasks.length;
@@ -124,6 +126,10 @@ ${metaSection}
 
   if (comparison) {
     report += generateComparisonSection(comparison);
+  }
+
+  if (blindComparison) {
+    report += generateBlindComparisonSection(blindComparison);
   }
 
   if (crossIterationComparison) {
@@ -239,7 +245,7 @@ ${result.output.slice(0, config.reportOutputTruncation) || '(no output)'}
  * Generate JSON report for programmatic analysis.
  */
 export async function generateJsonResults(options: ReportOptions): Promise<EvaluationReport> {
-  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison, crossIterationComparison } = options;
+  const { evaluation, results, scores, outputPath, metadata, runDetails, humanFeedback, comparison, blindComparison, crossIterationComparison } = options;
   const numRuns = options.numRuns ?? 1;
   const config = loadConfigSync();
   const summary = computeSummary(results, scores, numRuns);
@@ -292,6 +298,7 @@ export async function generateJsonResults(options: ReportOptions): Promise<Evalu
       ? humanFeedback
       : undefined,
     comparison,
+    blindComparison,
     crossIterationComparison,
   };
 
@@ -446,4 +453,42 @@ function costImpact(delta: number): string {
   if (delta > COST_IMPACT_THRESHOLD_USD) return 'Higher';
   if (delta < -COST_IMPACT_THRESHOLD_USD) return 'Lower';
   return 'Similar';
+}
+
+/**
+ * Generate the blind comparison section for the markdown report.
+ */
+function generateBlindComparisonSection(blind: BlindComparisonData): string {
+  const a = blind.aggregate;
+  const total = blind.tasks.length;
+
+  let section = `
+---
+
+## Blind A/B Comparison
+
+The judge evaluated both outputs without knowing which used the skill.
+
+| Preference | Count | Percentage |
+|------------|-------|------------|
+| With-skill preferred | ${a.withSkillPreferred} | ${total > 0 ? ((a.withSkillPreferred / total) * 100).toFixed(0) : 0}% |
+| Without-skill preferred | ${a.withoutSkillPreferred} | ${total > 0 ? ((a.withoutSkillPreferred / total) * 100).toFixed(0) : 0}% |
+| Tie | ${a.ties} | ${total > 0 ? ((a.ties / total) * 100).toFixed(0) : 0}% |
+
+### Per-Task Blind Results
+
+| Task | Labels (W/B) | A Adherence | A Output | B Adherence | B Output | Preferred | Condition | Bias? |
+|------|-------------|-------------|----------|-------------|----------|-----------|-----------|-------|
+`;
+
+  for (const t of blind.tasks) {
+    const labels = t.withSkillLabel === 'A' ? 'A/B' : 'B/A';
+    section += `| ${t.taskId} | ${labels} | ${t.outputA.adherence}/5 | ${t.outputA.outputQuality}/5 | ${t.outputB.adherence}/5 | ${t.outputB.outputQuality}/5 | ${t.preferred} | ${t.preferredCondition} | ${t.biasSignal ? 'Yes' : 'No'} |\n`;
+  }
+
+  if (a.biasSignalCount > 0) {
+    section += `\n> **Bias Alert:** ${a.biasSignalCount} task(s) show bias signals where the blind comparison disagrees with standard scoring. This may indicate the standard judge is biased by knowing which output used the skill.\n`;
+  }
+
+  return section;
 }

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -460,8 +460,7 @@ function costImpact(delta: number): string {
  */
 function generateBlindComparisonSection(blind: BlindComparisonData): string {
   const a = blind.aggregate;
-  const total = blind.tasks.length;
-  const evaluated = total - a.failedCount;
+  const evaluated = blind.tasks.length - a.failedCount;
 
   let section = `
 ---
@@ -485,7 +484,11 @@ Assignment shows the label order: with-skill / without-skill (e.g. A/B means A =
 
   for (const t of blind.tasks) {
     const labels = t.withSkillLabel === 'A' ? 'A/B' : 'B/A';
-    section += `| ${t.taskId} | ${labels} | ${t.outputA.instructionFollowing}/5 | ${t.outputA.outputQuality}/5 | ${t.outputB.instructionFollowing}/5 | ${t.outputB.outputQuality}/5 | ${t.preferred} | ${t.preferredCondition} | ${t.biasSignal ? 'Yes' : 'No'} |\n`;
+    const aInstr = t.failed ? 'N/A' : `${t.outputA.instructionFollowing}/5`;
+    const aOut = t.failed ? 'N/A' : `${t.outputA.outputQuality}/5`;
+    const bInstr = t.failed ? 'N/A' : `${t.outputB.instructionFollowing}/5`;
+    const bOut = t.failed ? 'N/A' : `${t.outputB.outputQuality}/5`;
+    section += `| ${t.taskId} | ${labels} | ${aInstr} | ${aOut} | ${bInstr} | ${bOut} | ${t.preferred} | ${t.preferredCondition} | ${t.biasSignal ? 'Yes' : 'No'} |\n`;
   }
 
   if (a.biasSignalCount > 0) {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -461,6 +461,7 @@ function costImpact(delta: number): string {
 function generateBlindComparisonSection(blind: BlindComparisonData): string {
   const a = blind.aggregate;
   const total = blind.tasks.length;
+  const evaluated = total - a.failedCount;
 
   let section = `
 ---
@@ -472,9 +473,9 @@ Assignment shows the label order: with-skill / without-skill (e.g. A/B means A =
 
 | Preference | Count | Percentage |
 |------------|-------|------------|
-| With-skill preferred | ${a.withSkillPreferred} | ${pct(a.withSkillPreferred, total)}% |
-| Without-skill preferred | ${a.withoutSkillPreferred} | ${pct(a.withoutSkillPreferred, total)}% |
-| Tie | ${a.ties} | ${pct(a.ties, total)}% |
+| With-skill preferred | ${a.withSkillPreferred} | ${pct(a.withSkillPreferred, evaluated)}% |
+| Without-skill preferred | ${a.withoutSkillPreferred} | ${pct(a.withoutSkillPreferred, evaluated)}% |
+| Tie | ${a.ties} | ${pct(a.ties, evaluated)}% |
 
 ### Per-Task Blind Results
 
@@ -492,7 +493,7 @@ Assignment shows the label order: with-skill / without-skill (e.g. A/B means A =
   }
 
   if (a.failedCount > 0) {
-    section += `\n> **Warning:** ${a.failedCount} blind judge call(s) failed and were recorded as ties with neutral scores.\n`;
+    section += `\n> **Warning:** ${a.failedCount} blind judge call(s) failed and were excluded from preference counts.\n`;
   }
 
   return section;

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { formatDelta, formatCategory } from '../utils/format.js';
+import { formatDelta, formatCategory, pct } from '../utils/format.js';
 import type {
   SkillEvaluation,
   TaskResult,
@@ -471,14 +471,14 @@ The judge evaluated both outputs without knowing which used the skill.
 
 | Preference | Count | Percentage |
 |------------|-------|------------|
-| With-skill preferred | ${a.withSkillPreferred} | ${total > 0 ? ((a.withSkillPreferred / total) * 100).toFixed(0) : 0}% |
-| Without-skill preferred | ${a.withoutSkillPreferred} | ${total > 0 ? ((a.withoutSkillPreferred / total) * 100).toFixed(0) : 0}% |
-| Tie | ${a.ties} | ${total > 0 ? ((a.ties / total) * 100).toFixed(0) : 0}% |
+| With-skill preferred | ${a.withSkillPreferred} | ${pct(a.withSkillPreferred, total)}% |
+| Without-skill preferred | ${a.withoutSkillPreferred} | ${pct(a.withoutSkillPreferred, total)}% |
+| Tie | ${a.ties} | ${pct(a.ties, total)}% |
 
 ### Per-Task Blind Results
 
-| Task | Labels (W/B) | A Adherence | A Output | B Adherence | B Output | Preferred | Condition | Bias? |
-|------|-------------|-------------|----------|-------------|----------|-----------|-----------|-------|
+| Task | Assignment | A Adherence | A Output | B Adherence | B Output | Preferred | Condition | Bias? |
+|------|------------|-------------|----------|-------------|----------|-----------|-----------|-------|
 `;
 
   for (const t of blind.tasks) {

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -415,15 +415,14 @@ export class SkillJudge {
    * Score all evaluation results.
    */
   async judgeAll(tasks: EvalTask[], results: TaskResult[], feedback?: HumanFeedback): Promise<JudgeScore[]> {
-    // TODO: Add concurrency cap (e.g. p-limit) if used with large task sets to avoid API rate limits.
     for (const task of tasks) {
       console.log(`Judging task ${task.id}...`);
     }
-    return Promise.all(
-      tasks.map((task, i) => {
+    return withConcurrencyLimit(
+      tasks.map((task, i) => () => {
         const taskFeedback = getFeedbackForTask(feedback, task.id);
         return this.judgeResult(task, results[i], taskFeedback);
-      })
+      }),
     );
   }
 
@@ -437,7 +436,7 @@ export class SkillJudge {
   ): Promise<{ outputA: BlindOutputScore; outputB: BlindOutputScore; preferred: 'A' | 'B' | 'tie'; reasoning: string } | null> {
     // Single-pass replacement avoids one substitution injecting a marker consumed by the next.
     const replacements: Record<string, string> = {
-      '__PROMPT__': prompt,
+      '__PROMPT__': prompt.slice(0, this.options.outputTruncation) || '(no prompt)',
       '__OUTPUT_A__': outputA.slice(0, this.options.outputTruncation) || '(no output)',
       '__OUTPUT_B__': outputB.slice(0, this.options.outputTruncation) || '(no output)',
     };
@@ -536,8 +535,27 @@ export const BLIND_BIAS_THRESHOLD = 0.05;
 export interface BlindCompareOptions {
   /** Override the random function (default: Math.random). Useful for deterministic tests. */
   randomFn?: () => number;
-  /** Override the bias detection threshold (default: BLIND_BIAS_THRESHOLD). */
+  /** @internal Override the bias detection threshold (default: BLIND_BIAS_THRESHOLD). Exposed for testing only. */
   biasThreshold?: number;
+}
+
+/**
+ * Map a blind judge's A/B preference back to with-skill / without-skill / tie.
+ *
+ * Exported for unit testing the mapping logic in isolation.
+ */
+export function mapPreferredToCondition(
+  preferred: 'A' | 'B' | 'tie',
+  withSkillIsA: boolean,
+): 'with-skill' | 'without-skill' | 'tie' {
+  if (preferred === 'tie') return 'tie';
+  if (
+    (preferred === 'A' && withSkillIsA) ||
+    (preferred === 'B' && !withSkillIsA)
+  ) {
+    return 'with-skill';
+  }
+  return 'without-skill';
 }
 
 /**
@@ -565,7 +583,9 @@ export async function blindCompareAll(
       ? task.withoutSkill.result.output
       : task.withSkill.result.output;
 
-    const result = await judge.blindCompare(task.withSkill.result.prompt, outputA, outputB);
+    // Both sides use the same prompt; use withSkill's copy.
+    const taskPrompt = task.withSkill.result.prompt;
+    const result = await judge.blindCompare(taskPrompt, outputA, outputB);
 
     if (!result) {
       // Failed blind judge call → tie, no bias signal
@@ -573,8 +593,8 @@ export async function blindCompareAll(
       return {
         taskId: task.taskId,
         withSkillLabel,
-        outputA: { instructionFollowing: 3, outputQuality: 3 },
-        outputB: { instructionFollowing: 3, outputQuality: 3 },
+        outputA: { instructionFollowing: 0, outputQuality: 0 },
+        outputB: { instructionFollowing: 0, outputQuality: 0 },
         preferred: 'tie',
         reasoning: 'Blind judge call failed',
         preferredCondition: 'tie',
@@ -583,18 +603,7 @@ export async function blindCompareAll(
       };
     }
 
-    // Map preference back to condition
-    let preferredCondition: 'with-skill' | 'without-skill' | 'tie';
-    if (result.preferred === 'tie') {
-      preferredCondition = 'tie';
-    } else if (
-      (result.preferred === 'A' && withSkillIsA) ||
-      (result.preferred === 'B' && !withSkillIsA)
-    ) {
-      preferredCondition = 'with-skill';
-    } else {
-      preferredCondition = 'without-skill';
-    }
+    const preferredCondition = mapPreferredToCondition(result.preferred, withSkillIsA);
 
     // Detect bias signal: standard scoring prefers with-skill but blind prefers without (or vice versa)
     const standardDelta = task.delta.weightedScoreDelta;
@@ -618,11 +627,10 @@ export async function blindCompareAll(
     };
   }
 
-  // TODO: Add concurrency cap (e.g. p-limit) if used with large task sets to avoid API rate limits.
   for (const task of tasks) {
     console.log(`Blind comparing task ${task.taskId}...`);
   }
-  const blindTasks = await Promise.all(tasks.map(processTask));
+  const blindTasks = await withConcurrencyLimit(tasks.map(t => () => processTask(t)));
 
   const aggregate = {
     withSkillPreferred: blindTasks.filter(t => t.preferredCondition === 'with-skill').length,
@@ -633,6 +641,31 @@ export async function blindCompareAll(
   };
 
   return { tasks: blindTasks, aggregate };
+}
+
+/** Default maximum number of concurrent API calls to the judge. */
+export const DEFAULT_CONCURRENCY = 5;
+
+/**
+ * Run async tasks with a concurrency limit.
+ */
+async function withConcurrencyLimit<T>(
+  factories: Array<() => Promise<T>>,
+  limit = DEFAULT_CONCURRENCY,
+): Promise<T[]> {
+  const results: T[] = new Array(factories.length);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < factories.length) {
+      const idx = next++;
+      results[idx] = await factories[idx]();
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, factories.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
 }
 
 function capitalize(s: string): string {

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -16,6 +16,10 @@ import type {
   FailureCategory,
   ChecklistItemResult,
   HumanFeedback,
+  BlindOutputScore,
+  BlindTaskComparison,
+  BlindComparisonData,
+  TaskComparison,
 } from '../types.js';
 import {
   isAssistantMessage,
@@ -83,6 +87,44 @@ Respond with a JSON object:
   "output_quality": <1-5>,
   "failure_category": "<category or none>",
   "reasoning": "<brief explanation of scores>"{checklistJsonField}
+}
+\`\`\`
+`;
+
+const BLIND_COMPARE_PROMPT_TEMPLATE = `You are an expert evaluator comparing two AI agent outputs for the same task. You do NOT know which output used a skill and which did not. Evaluate both fairly.
+
+## Task Prompt
+{prompt}
+
+## Output A
+{outputA}
+
+## Output B
+{outputB}
+
+## Scoring Instructions
+
+Score each output on two dimensions:
+
+1. **Adherence (1-5)**: How well does the output follow good practices and instructions?
+   - 5 = Excellent adherence
+   - 3 = Acceptable
+   - 1 = Poor adherence
+
+2. **Output Quality (1-5)**: Does the output meet the task requirements?
+   - 5 = Excellent quality
+   - 3 = Acceptable
+   - 1 = Poor quality
+
+3. **Preference**: Which output is better overall? "A", "B", or "tie"
+
+Respond with a JSON object:
+\`\`\`json
+{
+  "output_a": { "adherence": <1-5>, "output_quality": <1-5> },
+  "output_b": { "adherence": <1-5>, "output_quality": <1-5> },
+  "preferred": "<A, B, or tie>",
+  "reasoning": "<brief explanation of preference>"
 }
 \`\`\`
 `;
@@ -288,8 +330,6 @@ export class SkillJudge {
   }
 
   /**
-  /**
-  /**
    * Score a single evaluation result.
    */
   async judgeResult(task: EvalTask, result: TaskResult, feedback?: string): Promise<JudgeScore> {
@@ -370,6 +410,191 @@ export class SkillJudge {
     }
     return scores;
   }
+
+  /**
+   * Run a blind comparison of two outputs for the same task prompt.
+   */
+  async blindCompare(
+    prompt: string,
+    outputA: string,
+    outputB: string,
+  ): Promise<{ outputA: BlindOutputScore; outputB: BlindOutputScore; preferred: 'A' | 'B' | 'tie'; reasoning: string } | null> {
+    const judgePrompt = BLIND_COMPARE_PROMPT_TEMPLATE
+      .replace('{prompt}', prompt)
+      .replace('{outputA}', outputA.slice(0, this.options.outputTruncation) || '(no output)')
+      .replace('{outputB}', outputB.slice(0, this.options.outputTruncation) || '(no output)');
+
+    try {
+      let responseText = '';
+
+      for await (const message of query({
+        prompt: judgePrompt,
+        options: {
+          model: this.options.model,
+          allowedTools: [],
+          permissionMode: 'bypassPermissions',
+        },
+      })) {
+        if (isAssistantMessage(message)) {
+          const content = message.message.content;
+          for (const block of content) {
+            if (isTextBlock(block)) {
+              responseText += block.text;
+            }
+          }
+        }
+
+        if (isResultMessage(message)) {
+          if (message.result) {
+            responseText = message.result;
+          }
+        }
+      }
+
+      return parseBlindJudgeResponse(responseText);
+    } catch (error) {
+      console.warn(`Blind comparison failed: ${error instanceof Error ? error.message : 'unknown'}`);
+      return null;
+    }
+  }
+}
+
+/**
+ * Parse a blind judge response into scores and preference.
+ *
+ * Exported for testing.
+ */
+export function parseBlindJudgeResponse(
+  response: string,
+): { outputA: BlindOutputScore; outputB: BlindOutputScore; preferred: 'A' | 'B' | 'tie'; reasoning: string } | null {
+  const jsonStr = extractJsonObject(response);
+  if (!jsonStr) return null;
+
+  try {
+    const data = JSON.parse(jsonStr);
+
+    if (!data.output_a || !data.output_b) return null;
+
+    const clamp = (v: unknown, min: number, max: number): number => {
+      const n = Number(v);
+      if (isNaN(n)) return min;
+      return Math.max(min, Math.min(max, n));
+    };
+
+    const outputA: BlindOutputScore = {
+      adherence: clamp(data.output_a.adherence, 1, 5),
+      outputQuality: clamp(data.output_a.output_quality, 1, 5),
+    };
+
+    const outputB: BlindOutputScore = {
+      adherence: clamp(data.output_b.adherence, 1, 5),
+      outputQuality: clamp(data.output_b.output_quality, 1, 5),
+    };
+
+    let preferred: 'A' | 'B' | 'tie';
+    const rawPref = String(data.preferred ?? '').toUpperCase();
+    if (rawPref === 'A') preferred = 'A';
+    else if (rawPref === 'B') preferred = 'B';
+    else preferred = 'tie';
+
+    return {
+      outputA,
+      outputB,
+      preferred,
+      reasoning: String(data.reasoning ?? ''),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Minimum weighted score delta to classify bias signal. */
+const BLIND_BIAS_THRESHOLD = 0.02;
+
+/**
+ * Run blind comparison for all tasks in a comparison set.
+ *
+ * Randomizes A/B assignment per task, calls the blind judge, maps results
+ * back, and detects bias signals.
+ */
+export async function blindCompareAll(
+  tasks: TaskComparison[],
+  judge: SkillJudge,
+): Promise<BlindComparisonData> {
+  const blindTasks: BlindTaskComparison[] = [];
+
+  for (const task of tasks) {
+    const withSkillIsA = Math.random() < 0.5;
+    const withSkillLabel: 'A' | 'B' = withSkillIsA ? 'A' : 'B';
+
+    const outputA = withSkillIsA
+      ? task.withSkill.result.output
+      : task.withoutSkill.result.output;
+    const outputB = withSkillIsA
+      ? task.withoutSkill.result.output
+      : task.withSkill.result.output;
+
+    console.log(`Blind comparing task ${task.taskId}...`);
+    const result = await judge.blindCompare(task.withSkill.result.prompt, outputA, outputB);
+
+    if (!result) {
+      // Failed blind judge call → tie, no bias signal
+      console.warn(`Blind comparison failed for task ${task.taskId}, recording as tie`);
+      blindTasks.push({
+        taskId: task.taskId,
+        withSkillLabel,
+        outputA: { adherence: 3, outputQuality: 3 },
+        outputB: { adherence: 3, outputQuality: 3 },
+        preferred: 'tie',
+        reasoning: 'Blind judge call failed',
+        preferredCondition: 'tie',
+        biasSignal: false,
+      });
+      continue;
+    }
+
+    // Map preference back to condition
+    let preferredCondition: 'with-skill' | 'without-skill' | 'tie';
+    if (result.preferred === 'tie') {
+      preferredCondition = 'tie';
+    } else if (
+      (result.preferred === 'A' && withSkillIsA) ||
+      (result.preferred === 'B' && !withSkillIsA)
+    ) {
+      preferredCondition = 'with-skill';
+    } else {
+      preferredCondition = 'without-skill';
+    }
+
+    // Detect bias signal: standard scoring prefers with-skill but blind prefers without (or vice versa)
+    const standardDelta = task.delta.weightedScoreDelta;
+    const standardPrefersWithSkill = standardDelta > BLIND_BIAS_THRESHOLD;
+    const standardPrefersWithout = standardDelta < -BLIND_BIAS_THRESHOLD;
+    const biasSignal =
+      preferredCondition !== 'tie' &&
+      ((standardPrefersWithSkill && preferredCondition === 'without-skill') ||
+       (standardPrefersWithout && preferredCondition === 'with-skill'));
+
+    blindTasks.push({
+      taskId: task.taskId,
+      withSkillLabel,
+      outputA: result.outputA,
+      outputB: result.outputB,
+      preferred: result.preferred,
+      reasoning: result.reasoning,
+      preferredCondition,
+      biasSignal,
+    });
+  }
+
+  const aggregate = {
+    withSkillPreferred: blindTasks.filter(t => t.preferredCondition === 'with-skill').length,
+    withoutSkillPreferred: blindTasks.filter(t => t.preferredCondition === 'without-skill').length,
+    ties: blindTasks.filter(t => t.preferredCondition === 'tie').length,
+    biasSignalCount: blindTasks.filter(t => t.biasSignal).length,
+  };
+
+  return { tasks: blindTasks, aggregate };
 }
 
 function capitalize(s: string): string {

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -435,6 +435,8 @@ export class SkillJudge {
     outputB: string,
   ): Promise<{ outputA: BlindOutputScore; outputB: BlindOutputScore; preferred: 'A' | 'B' | 'tie'; reasoning: string } | null> {
     // Single-pass replacement avoids one substitution injecting a marker consumed by the next.
+    // Reuse outputTruncation for prompt too — prompts are typically short,
+    // but this prevents pathological cases from bloating the judge call.
     const replacements: Record<string, string> = {
       '__PROMPT__': prompt.slice(0, this.options.outputTruncation) || '(no prompt)',
       '__OUTPUT_A__': outputA.slice(0, this.options.outputTruncation) || '(no output)',
@@ -593,8 +595,8 @@ export async function blindCompareAll(
       return {
         taskId: task.taskId,
         withSkillLabel,
-        outputA: { instructionFollowing: 0, outputQuality: 0 },
-        outputB: { instructionFollowing: 0, outputQuality: 0 },
+        outputA: { instructionFollowing: 1, outputQuality: 1 },
+        outputB: { instructionFollowing: 1, outputQuality: 1 },
         preferred: 'tie',
         reasoning: 'Blind judge call failed',
         preferredCondition: 'tie',
@@ -658,6 +660,7 @@ async function withConcurrencyLimit<T>(
 
   async function worker(): Promise<void> {
     while (next < factories.length) {
+      // Safe: JS is single-threaded; `next++` is atomic relative to the event loop.
       const idx = next++;
       results[idx] = await factories[idx]();
     }

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -91,25 +91,39 @@ Respond with a JSON object:
 \`\`\`
 `;
 
+/**
+ * Blind comparison prompt template.
+ *
+ * Design note: This prompt intentionally uses a *generic* rubric — it does NOT
+ * reference skill-specific criteria, checklist items, or the expected skill.
+ * That keeps the judge blind to which output used the skill. As a result, the
+ * "instruction_following" dimension here is broader than the standard judge's
+ * "adherence" (which measures compliance with the *skill's* instructions).
+ * Some disagreement between blind and standard scores is expected and does not
+ * necessarily indicate bias — it may reflect the different evaluation rubrics.
+ *
+ * The template uses indexed placeholders (__PROMPT__, __OUTPUT_A__, __OUTPUT_B__)
+ * to avoid conflicts if agent output contains curly-brace template markers.
+ */
 const BLIND_COMPARE_PROMPT_TEMPLATE = `You are an expert evaluator comparing two AI agent outputs for the same task. You do NOT know which output used a skill and which did not. Evaluate both fairly.
 
 ## Task Prompt
-{prompt}
+__PROMPT__
 
 ## Output A
-{outputA}
+__OUTPUT_A__
 
 ## Output B
-{outputB}
+__OUTPUT_B__
 
 ## Scoring Instructions
 
 Score each output on two dimensions:
 
-1. **Adherence (1-5)**: How well does the output follow good practices and instructions?
-   - 5 = Excellent adherence
+1. **Instruction Following (1-5)**: How well does the output follow good practices and instructions?
+   - 5 = Excellent instruction following
    - 3 = Acceptable
-   - 1 = Poor adherence
+   - 1 = Poor instruction following
 
 2. **Output Quality (1-5)**: Does the output meet the task requirements?
    - 5 = Excellent quality
@@ -121,8 +135,8 @@ Score each output on two dimensions:
 Respond with a JSON object:
 \`\`\`json
 {
-  "output_a": { "adherence": <1-5>, "output_quality": <1-5> },
-  "output_b": { "adherence": <1-5>, "output_quality": <1-5> },
+  "output_a": { "instruction_following": <1-5>, "output_quality": <1-5> },
+  "output_b": { "instruction_following": <1-5>, "output_quality": <1-5> },
   "preferred": "<A, B, or tie>",
   "reasoning": "<brief explanation of preference>"
 }
@@ -419,10 +433,16 @@ export class SkillJudge {
     outputA: string,
     outputB: string,
   ): Promise<{ outputA: BlindOutputScore; outputB: BlindOutputScore; preferred: 'A' | 'B' | 'tie'; reasoning: string } | null> {
-    const judgePrompt = BLIND_COMPARE_PROMPT_TEMPLATE
-      .replace('{prompt}', prompt)
-      .replace('{outputA}', outputA.slice(0, this.options.outputTruncation) || '(no output)')
-      .replace('{outputB}', outputB.slice(0, this.options.outputTruncation) || '(no output)');
+    // Single-pass replacement avoids one substitution injecting a marker consumed by the next.
+    const replacements: Record<string, string> = {
+      '__PROMPT__': prompt,
+      '__OUTPUT_A__': outputA.slice(0, this.options.outputTruncation) || '(no output)',
+      '__OUTPUT_B__': outputB.slice(0, this.options.outputTruncation) || '(no output)',
+    };
+    const judgePrompt = BLIND_COMPARE_PROMPT_TEMPLATE.replace(
+      /__PROMPT__|__OUTPUT_A__|__OUTPUT_B__/g,
+      (match) => replacements[match],
+    );
 
     try {
       let responseText = '';
@@ -482,12 +502,12 @@ export function parseBlindJudgeResponse(
     };
 
     const outputA: BlindOutputScore = {
-      adherence: clamp(data.output_a.adherence, 1, 5),
+      instructionFollowing: clamp(data.output_a.instruction_following, 1, 5),
       outputQuality: clamp(data.output_a.output_quality, 1, 5),
     };
 
     const outputB: BlindOutputScore = {
-      adherence: clamp(data.output_b.adherence, 1, 5),
+      instructionFollowing: clamp(data.output_b.instruction_following, 1, 5),
       outputQuality: clamp(data.output_b.output_quality, 1, 5),
     };
 
@@ -511,20 +531,26 @@ export function parseBlindJudgeResponse(
 /** Minimum weighted score delta to classify bias signal. */
 export const BLIND_BIAS_THRESHOLD = 0.02;
 
+export interface BlindCompareOptions {
+  /** Override the random function (default: Math.random). Useful for deterministic tests. */
+  randomFn?: () => number;
+}
+
 /**
  * Run blind comparison for all tasks in a comparison set.
  *
- * Randomizes A/B assignment per task, calls the blind judge, maps results
- * back, and detects bias signals.
+ * Randomizes A/B assignment per task, calls the blind judge in parallel,
+ * maps results back, and detects bias signals.
  */
 export async function blindCompareAll(
   tasks: TaskComparison[],
   judge: SkillJudge,
+  options?: BlindCompareOptions,
 ): Promise<BlindComparisonData> {
-  const blindTasks: BlindTaskComparison[] = [];
+  const random = options?.randomFn ?? Math.random;
 
-  for (const task of tasks) {
-    const withSkillIsA = Math.random() < 0.5;
+  async function processTask(task: TaskComparison): Promise<BlindTaskComparison> {
+    const withSkillIsA = random() < 0.5;
     const withSkillLabel: 'A' | 'B' = withSkillIsA ? 'A' : 'B';
 
     const outputA = withSkillIsA
@@ -540,18 +566,17 @@ export async function blindCompareAll(
     if (!result) {
       // Failed blind judge call → tie, no bias signal
       console.warn(`Blind comparison failed for task ${task.taskId}, recording as tie`);
-      blindTasks.push({
+      return {
         taskId: task.taskId,
         withSkillLabel,
-        outputA: { adherence: 3, outputQuality: 3 },
-        outputB: { adherence: 3, outputQuality: 3 },
+        outputA: { instructionFollowing: 3, outputQuality: 3 },
+        outputB: { instructionFollowing: 3, outputQuality: 3 },
         preferred: 'tie',
         reasoning: 'Blind judge call failed',
         preferredCondition: 'tie',
         biasSignal: false,
         failed: true,
-      });
-      continue;
+      };
     }
 
     // Map preference back to condition
@@ -576,7 +601,7 @@ export async function blindCompareAll(
       ((standardPrefersWithSkill && preferredCondition === 'without-skill') ||
        (standardPrefersWithout && preferredCondition === 'with-skill'));
 
-    blindTasks.push({
+    return {
       taskId: task.taskId,
       withSkillLabel,
       outputA: result.outputA,
@@ -586,8 +611,10 @@ export async function blindCompareAll(
       preferredCondition,
       biasSignal,
       failed: false,
-    });
+    };
   }
+
+  const blindTasks = await Promise.all(tasks.map(processTask));
 
   const aggregate = {
     withSkillPreferred: blindTasks.filter(t => t.preferredCondition === 'with-skill').length,

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -105,7 +105,7 @@ Respond with a JSON object:
  * The template uses indexed placeholders (__PROMPT__, __OUTPUT_A__, __OUTPUT_B__)
  * to avoid conflicts if agent output contains curly-brace template markers.
  */
-const BLIND_COMPARE_PROMPT_TEMPLATE = `You are an expert evaluator comparing two AI agent outputs for the same task. You do NOT know which output used a skill and which did not. Evaluate both fairly.
+const BLIND_COMPARE_PROMPT_TEMPLATE = `You are an expert evaluator comparing two AI agent outputs for the same task. You do NOT know which output used a skill and which did not. Evaluate each output on its own merits. The order of presentation (A vs. B) should not influence your scoring.
 
 ## Task Prompt
 __PROMPT__
@@ -416,9 +416,11 @@ export class SkillJudge {
    */
   async judgeAll(tasks: EvalTask[], results: TaskResult[], feedback?: HumanFeedback): Promise<JudgeScore[]> {
     // TODO: Add concurrency cap (e.g. p-limit) if used with large task sets to avoid API rate limits.
+    for (const task of tasks) {
+      console.log(`Judging task ${task.id}...`);
+    }
     return Promise.all(
       tasks.map((task, i) => {
-        console.log(`Judging task ${task.id}...`);
         const taskFeedback = getFeedbackForTask(feedback, task.id);
         return this.judgeResult(task, results[i], taskFeedback);
       })
@@ -563,7 +565,6 @@ export async function blindCompareAll(
       ? task.withoutSkill.result.output
       : task.withSkill.result.output;
 
-    console.log(`Blind comparing task ${task.taskId}...`);
     const result = await judge.blindCompare(task.withSkill.result.prompt, outputA, outputB);
 
     if (!result) {
@@ -618,12 +619,15 @@ export async function blindCompareAll(
   }
 
   // TODO: Add concurrency cap (e.g. p-limit) if used with large task sets to avoid API rate limits.
+  for (const task of tasks) {
+    console.log(`Blind comparing task ${task.taskId}...`);
+  }
   const blindTasks = await Promise.all(tasks.map(processTask));
 
   const aggregate = {
     withSkillPreferred: blindTasks.filter(t => t.preferredCondition === 'with-skill').length,
     withoutSkillPreferred: blindTasks.filter(t => t.preferredCondition === 'without-skill').length,
-    ties: blindTasks.filter(t => t.preferredCondition === 'tie').length,
+    ties: blindTasks.filter(t => t.preferredCondition === 'tie' && !t.failed).length,
     biasSignalCount: blindTasks.filter(t => t.biasSignal).length,
     failedCount: blindTasks.filter(t => t.failed).length,
   };

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -592,6 +592,7 @@ export async function blindCompareAll(
     withoutSkillPreferred: blindTasks.filter(t => t.preferredCondition === 'without-skill').length,
     ties: blindTasks.filter(t => t.preferredCondition === 'tie').length,
     biasSignalCount: blindTasks.filter(t => t.biasSignal).length,
+    failedCount: blindTasks.filter(t => t.reasoning === 'Blind judge call failed').length,
   };
 
   return { tasks: blindTasks, aggregate };

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -549,6 +549,7 @@ export async function blindCompareAll(
         reasoning: 'Blind judge call failed',
         preferredCondition: 'tie',
         biasSignal: false,
+        failed: true,
       });
       continue;
     }
@@ -584,6 +585,7 @@ export async function blindCompareAll(
       reasoning: result.reasoning,
       preferredCondition,
       biasSignal,
+      failed: false,
     });
   }
 
@@ -592,7 +594,7 @@ export async function blindCompareAll(
     withoutSkillPreferred: blindTasks.filter(t => t.preferredCondition === 'without-skill').length,
     ties: blindTasks.filter(t => t.preferredCondition === 'tie').length,
     biasSignalCount: blindTasks.filter(t => t.biasSignal).length,
-    failedCount: blindTasks.filter(t => t.reasoning === 'Blind judge call failed').length,
+    failedCount: blindTasks.filter(t => t.failed).length,
   };
 
   return { tasks: blindTasks, aggregate };

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -415,14 +415,14 @@ export class SkillJudge {
    * Score all evaluation results.
    */
   async judgeAll(tasks: EvalTask[], results: TaskResult[], feedback?: HumanFeedback): Promise<JudgeScore[]> {
-    const scores: JudgeScore[] = [];
-    for (let i = 0; i < tasks.length; i++) {
-      console.log(`Judging task ${tasks[i].id}...`);
-      const taskFeedback = getFeedbackForTask(feedback, tasks[i].id);
-      const score = await this.judgeResult(tasks[i], results[i], taskFeedback);
-      scores.push(score);
-    }
-    return scores;
+    // TODO: Add concurrency cap (e.g. p-limit) if used with large task sets to avoid API rate limits.
+    return Promise.all(
+      tasks.map((task, i) => {
+        console.log(`Judging task ${task.id}...`);
+        const taskFeedback = getFeedbackForTask(feedback, task.id);
+        return this.judgeResult(task, results[i], taskFeedback);
+      })
+    );
   }
 
   /**
@@ -528,12 +528,14 @@ export function parseBlindJudgeResponse(
   }
 }
 
-/** Minimum weighted score delta to classify bias signal. */
-export const BLIND_BIAS_THRESHOLD = 0.02;
+/** Minimum weighted score delta to classify bias signal (on 0-1 scale). */
+export const BLIND_BIAS_THRESHOLD = 0.05;
 
 export interface BlindCompareOptions {
   /** Override the random function (default: Math.random). Useful for deterministic tests. */
   randomFn?: () => number;
+  /** Override the bias detection threshold (default: BLIND_BIAS_THRESHOLD). */
+  biasThreshold?: number;
 }
 
 /**
@@ -548,6 +550,7 @@ export async function blindCompareAll(
   options?: BlindCompareOptions,
 ): Promise<BlindComparisonData> {
   const random = options?.randomFn ?? Math.random;
+  const threshold = options?.biasThreshold ?? BLIND_BIAS_THRESHOLD;
 
   async function processTask(task: TaskComparison): Promise<BlindTaskComparison> {
     const withSkillIsA = random() < 0.5;
@@ -594,8 +597,8 @@ export async function blindCompareAll(
 
     // Detect bias signal: standard scoring prefers with-skill but blind prefers without (or vice versa)
     const standardDelta = task.delta.weightedScoreDelta;
-    const standardPrefersWithSkill = standardDelta > BLIND_BIAS_THRESHOLD;
-    const standardPrefersWithout = standardDelta < -BLIND_BIAS_THRESHOLD;
+    const standardPrefersWithSkill = standardDelta > threshold;
+    const standardPrefersWithout = standardDelta < -threshold;
     const biasSignal =
       preferredCondition !== 'tie' &&
       ((standardPrefersWithSkill && preferredCondition === 'without-skill') ||
@@ -614,6 +617,7 @@ export async function blindCompareAll(
     };
   }
 
+  // TODO: Add concurrency cap (e.g. p-limit) if used with large task sets to avoid API rate limits.
   const blindTasks = await Promise.all(tasks.map(processTask));
 
   const aggregate = {

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -509,7 +509,7 @@ export function parseBlindJudgeResponse(
 }
 
 /** Minimum weighted score delta to classify bias signal. */
-const BLIND_BIAS_THRESHOLD = 0.02;
+export const BLIND_BIAS_THRESHOLD = 0.02;
 
 /**
  * Run blind comparison for all tasks in a comparison set.

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,6 +253,7 @@ export interface EvaluationReport {
   }>;
   humanFeedback?: HumanFeedback;
   comparison?: ComparisonData;
+  blindComparison?: BlindComparisonData;
   crossIterationComparison?: ComparisonResult;
 }
 
@@ -341,6 +342,36 @@ export interface ComparisonResult {
   taskDeltas: TaskDelta[];
   tasksOnlyInCurrent: string[];
   tasksOnlyInPrevious: string[];
+}
+
+// ============================================
+// Blind Comparison Types
+// ============================================
+
+export interface BlindOutputScore {
+  adherence: number;    // 1-5
+  outputQuality: number; // 1-5
+}
+
+export interface BlindTaskComparison {
+  taskId: string;
+  withSkillLabel: 'A' | 'B';           // which label the with-skill output got
+  outputA: BlindOutputScore;
+  outputB: BlindOutputScore;
+  preferred: 'A' | 'B' | 'tie';
+  reasoning: string;
+  preferredCondition: 'with-skill' | 'without-skill' | 'tie';
+  biasSignal: boolean;                  // blind disagrees with standard scoring
+}
+
+export interface BlindComparisonData {
+  tasks: BlindTaskComparison[];
+  aggregate: {
+    withSkillPreferred: number;
+    withoutSkillPreferred: number;
+    ties: number;
+    biasSignalCount: number;
+  };
 }
 
 // ============================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -371,6 +371,7 @@ export interface BlindComparisonData {
     withoutSkillPreferred: number;
     ties: number;
     biasSignalCount: number;
+    failedCount: number;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -349,8 +349,8 @@ export interface ComparisonResult {
 // ============================================
 
 export interface BlindOutputScore {
-  adherence: number;    // 1-5
-  outputQuality: number; // 1-5
+  instructionFollowing: number; // 1-5 (generic rubric, distinct from skill-specific "adherence")
+  outputQuality: number;       // 1-5
 }
 
 export interface BlindTaskComparison {

--- a/src/types.ts
+++ b/src/types.ts
@@ -362,6 +362,7 @@ export interface BlindTaskComparison {
   reasoning: string;
   preferredCondition: 'with-skill' | 'without-skill' | 'tie';
   biasSignal: boolean;                  // blind disagrees with standard scoring
+  failed: boolean;                      // true when blind judge call failed
 }
 
 export interface BlindComparisonData {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -12,6 +12,13 @@ export function formatDelta(value: number, decimals = 2): string {
 }
 
 /**
+ * Format a percentage string from count/total. Returns '0' when total is 0.
+ */
+export function pct(count: number, total: number): string {
+  return total > 0 ? ((count / total) * 100).toFixed(0) : '0';
+}
+
+/**
  * Format a failure category slug as a human-readable label.
  */
 export function formatCategory(cat: string): string {


### PR DESCRIPTION
## Summary
- Adds `--blind-compare` flag that runs alongside `--compare` to present both outputs anonymized as "Output A" / "Output B" to a separate judge call, detecting scoring bias
- Includes new types (`BlindOutputScore`, `BlindTaskComparison`, `BlindComparisonData`), judge logic (`parseBlindJudgeResponse`, `blindCompareAll`), pipeline orchestration, CLI flag, report sections (markdown + GitHub summary), and GitHub Action inputs/outputs
- 18 new tests covering parser, bias detection, label mapping, aggregate computation, and GitHub summary rendering

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` compiles without errors
- [x] `npx vitest run` — all 166 tests pass (13 test files)
- [ ] Manual: `skilljack-evals run tasks.yaml --compare --blind-compare` produces report with Blind Comparison section
- [ ] Verify `--blind-compare` without `--compare` throws error

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)