### PR TITLE
Add GitHub Copilot SDK runner

### DIFF
--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -124,7 +124,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVAL_FILE: ${{ inputs.eval-file }}
           NO_JUDGE: ${{ inputs.no-judge }}
           RUNS_NUMBER: ${{ inputs.runs-number }}

--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -70,13 +70,17 @@ jobs:
           - runner: vercel-ai
             model: 'openrouter:openai/gpt-oss-120b'
             name: vercel-ai-openrouter-gpt-oss
+          - runner: copilot-sdk
+            model: gpt-5
+            name: copilot-sdk-gpt
+            node-version: '23'
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version || '20' }}
 
       - name: Install dependencies
         run: npm install
@@ -88,6 +92,8 @@ jobs:
             npm install ai zod @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google @openrouter/ai-sdk-provider
           elif [ "${{ matrix.runner }}" = "openai-agents" ]; then
             npm install @openai/agents openai
+          elif [ "${{ matrix.runner }}" = "copilot-sdk" ]; then
+            npm install @github/copilot-sdk
           fi
 
       - name: Build
@@ -114,6 +120,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVAL_FILE: ${{ inputs.eval-file }}
           NO_JUDGE: ${{ inputs.no-judge }}
           RUNS_NUMBER: ${{ inputs.runs-number }}

--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -71,7 +71,7 @@ jobs:
             model: 'openrouter:openai/gpt-oss-120b'
             name: vercel-ai-openrouter-gpt-oss
           - runner: copilot-sdk
-            model: gpt-5
+            model: gpt-5.2
             name: copilot-sdk-gpt
             # skillDirectories doesn't work in @github/copilot v1.0.10 (github/copilot-sdk#629).
             # Agent discovers skills by file browsing, which is inconsistent.

--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -84,7 +84,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '23'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -79,6 +79,12 @@ jobs:
             # Thresholds set to 0 as smoke test until SDK bug is fixed.
             threshold-discovery: '0'
             threshold-score: '0'
+          - runner: copilot-sdk
+            model: claude-sonnet-4-6
+            name: copilot-sdk-sonnet
+            node-version: '23'
+            threshold-discovery: '0'
+            threshold-score: '0'
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -74,6 +74,11 @@ jobs:
             model: gpt-5
             name: copilot-sdk-gpt
             node-version: '23'
+            # skillDirectories doesn't work in @github/copilot v1.0.10 (github/copilot-sdk#629).
+            # Agent discovers skills by file browsing, which is inconsistent.
+            # Thresholds set to 0 as smoke test until SDK bug is fixed.
+            threshold-discovery: '0'
+            threshold-score: '0'
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4
@@ -114,6 +119,12 @@ jobs:
           if [ "$GENERATE_FEEDBACK" = "true" ]; then
             ARGS="$ARGS --generate-feedback results/feedback-template.json"
           fi
+          if [ -n "$THRESHOLD_DISCOVERY" ]; then
+            ARGS="$ARGS --threshold-discovery $THRESHOLD_DISCOVERY"
+          fi
+          if [ -n "$THRESHOLD_SCORE" ]; then
+            ARGS="$ARGS --threshold-score $THRESHOLD_SCORE"
+          fi
           node dist/src/cli.js run "$EVAL_FILE" $ARGS
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -129,6 +140,8 @@ jobs:
           GENERATE_FEEDBACK: ${{ inputs.generate-feedback }}
           RUNNER: ${{ matrix.runner }}
           MODEL: ${{ matrix.model }}
+          THRESHOLD_DISCOVERY: ${{ matrix.threshold-discovery || '' }}
+          THRESHOLD_SCORE: ${{ matrix.threshold-score || '' }}
 
       - name: Upload results
         if: always()

--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -73,7 +73,6 @@ jobs:
           - runner: copilot-sdk
             model: gpt-5
             name: copilot-sdk-gpt
-            node-version: '23'
             # skillDirectories doesn't work in @github/copilot v1.0.10 (github/copilot-sdk#629).
             # Agent discovers skills by file browsing, which is inconsistent.
             # Thresholds set to 0 as smoke test until SDK bug is fixed.
@@ -82,7 +81,6 @@ jobs:
           - runner: copilot-sdk
             model: claude-sonnet-4-6
             name: copilot-sdk-sonnet
-            node-version: '23'
             threshold-discovery: '0'
             threshold-score: '0'
     name: ${{ matrix.name }}
@@ -91,7 +89,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version || '20' }}
+          node-version: '23'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -70,19 +70,14 @@ jobs:
           - runner: vercel-ai
             model: 'openrouter:openai/gpt-oss-120b'
             name: vercel-ai-openrouter-gpt-oss
-          - runner: copilot-sdk
-            model: gpt-5.2
-            name: copilot-sdk-gpt
-            # skillDirectories doesn't work in @github/copilot v1.0.10 (github/copilot-sdk#629).
-            # Agent discovers skills by file browsing, which is inconsistent.
-            # Thresholds set to 0 as smoke test until SDK bug is fixed.
-            threshold-discovery: '0'
-            threshold-score: '0'
-          - runner: copilot-sdk
-            model: claude-sonnet-4-6
-            name: copilot-sdk-sonnet
-            threshold-discovery: '0'
-            threshold-score: '0'
+          # copilot-sdk entries disabled until github/copilot-sdk#629 is fixed
+          # (skillDirectories not working — agent relies on inconsistent file browsing)
+          # - runner: copilot-sdk
+          #   model: gpt-5.2
+          #   name: copilot-sdk-gpt
+          # - runner: copilot-sdk
+          #   model: claude-sonnet-4-6
+          #   name: copilot-sdk-sonnet
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4
@@ -123,12 +118,6 @@ jobs:
           if [ "$GENERATE_FEEDBACK" = "true" ]; then
             ARGS="$ARGS --generate-feedback results/feedback-template.json"
           fi
-          if [ -n "$THRESHOLD_DISCOVERY" ]; then
-            ARGS="$ARGS --threshold-discovery $THRESHOLD_DISCOVERY"
-          fi
-          if [ -n "$THRESHOLD_SCORE" ]; then
-            ARGS="$ARGS --threshold-score $THRESHOLD_SCORE"
-          fi
           node dist/src/cli.js run "$EVAL_FILE" $ARGS
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -144,8 +133,6 @@ jobs:
           GENERATE_FEEDBACK: ${{ inputs.generate-feedback }}
           RUNNER: ${{ matrix.runner }}
           MODEL: ${{ matrix.model }}
-          THRESHOLD_DISCOVERY: ${{ matrix.threshold-discovery || '' }}
-          THRESHOLD_SCORE: ${{ matrix.threshold-score || '' }}
 
       - name: Upload results
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ CLI for evaluating [Agent Skills](https://agentskills.io/home) - a format for ex
 - `src/runner/runner.ts` - Claude Agent SDK runner (SkillEvalRunner)
 - `src/runner/vercel-ai-runner.ts` - Vercel AI SDK runner
 - `src/runner/openai-agents-runner.ts` - OpenAI Agents SDK runner
+- `src/runner/copilot-sdk-runner.ts` - GitHub Copilot SDK runner
 - `src/runner/base-runner.ts` - Shared runner base class
 - `src/runner/runner-factory.ts` - Runner selection factory
 - `src/runner/skill-setup.ts` - Copy/cleanup skills in .claude/skills/
@@ -37,15 +38,16 @@ npm run start      # Run compiled CLI
 ## Architecture
 
 ```
-YAML tasks → Config → Runner (Claude SDK | Vercel AI | OpenAI Agents) → Scorer (deterministic + LLM judge) → Report
+YAML tasks → Config → Runner (Claude SDK | Vercel AI | OpenAI Agents | Copilot SDK) → Scorer (deterministic + LLM judge) → Report
 ```
 
 ## Runners
 
-Three runners selected via `--runner` flag:
+Four runners selected via `--runner` flag:
 - `claude-sdk` (default) — uses Claude Agent SDK, model aliases like `sonnet`, `haiku`
 - `vercel-ai` — uses Vercel AI SDK, model format `"provider:model"` (e.g., `anthropic:claude-sonnet-4-6`, `google:gemini-2.5-pro`, `openai:gpt-5.2`, `openrouter:deepseek/deepseek-v3.2`)
 - `openai-agents` — uses OpenAI Agents SDK, plain model names (e.g., `gpt-5.2`)
+- `copilot-sdk` — uses GitHub Copilot SDK, model names like `gpt-5`, `claude-sonnet-4-6`
 
 ## Scoring
 
@@ -74,6 +76,7 @@ Two methods, run independently or together:
 Peer dependencies (install as needed for non-Claude runners):
 - `ai`, `zod`, `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`, `@openrouter/ai-sdk-provider` - Vercel AI SDK
 - `@openai/agents`, `openai` - OpenAI Agents SDK
+- `@github/copilot-sdk` - GitHub Copilot SDK
 
 ## Environment
 
@@ -82,6 +85,8 @@ Requires API key for selected runner in environment or `.env` file:
 - Vercel AI (openai:) / OpenAI Agents: `OPENAI_API_KEY`
 - Vercel AI (google:): `GOOGLE_GENERATIVE_AI_API_KEY`
 - Vercel AI (openrouter:): `OPENROUTER_API_KEY`
+- Copilot SDK (GitHub auth): `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`
+- Copilot SDK (BYOK): Set provider config in `eval.config.yaml`
 
 For Bedrock: set `CLAUDE_CODE_USE_BEDROCK=1` + AWS env vars.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,8 @@ Requires API key for selected runner in environment or `.env` file:
 - Vercel AI (openai:) / OpenAI Agents: `OPENAI_API_KEY`
 - Vercel AI (google:): `GOOGLE_GENERATIVE_AI_API_KEY`
 - Vercel AI (openrouter:): `OPENROUTER_API_KEY`
-- Copilot SDK (GitHub auth): `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`
-- Copilot SDK (BYOK): Set provider config in `eval.config.yaml`
+- Copilot SDK (GitHub auth): `COPILOT_GITHUB_TOKEN` (must have Copilot permissions)
+- Copilot SDK (BYOK): Auto-detects `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` when no Copilot token
 
 For Bedrock: set `CLAUDE_CODE_USE_BEDROCK=1` + AWS env vars.
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Path to tasks YAML file'
     required: true
   runner:
-    description: 'Runner type: claude-sdk, vercel-ai, or openai-agents'
+    description: 'Runner type: claude-sdk, vercel-ai, openai-agents, or copilot-sdk'
     required: false
     default: 'claude-sdk'
   model:
@@ -68,6 +68,9 @@ inputs:
     required: false
   openrouter-api-key:
     description: 'OpenRouter API key for vercel-ai (openrouter:) runner (or use OPENROUTER_API_KEY env var)'
+    required: false
+  github-token:
+    description: 'GitHub token for copilot-sdk runner auth (or use GITHUB_TOKEN env var)'
     required: false
   generate-feedback:
     description: 'Path to write feedback template JSON after run'

--- a/action/action.yml
+++ b/action/action.yml
@@ -70,7 +70,7 @@ inputs:
     description: 'OpenRouter API key for vercel-ai (openrouter:) runner (or use OPENROUTER_API_KEY env var)'
     required: false
   github-token:
-    description: 'GitHub token for copilot-sdk runner auth (or use GITHUB_TOKEN env var)'
+    description: 'GitHub token for copilot-sdk runner auth (set as COPILOT_GITHUB_TOKEN; must have Copilot permissions)'
     required: false
   generate-feedback:
     description: 'Path to write feedback template JSON after run'

--- a/action/index.ts
+++ b/action/index.ts
@@ -64,6 +64,12 @@ async function run(): Promise<void> {
       core.setSecret(openrouterKey);
     }
 
+    const githubToken = core.getInput('github-token') || process.env.GITHUB_TOKEN;
+    if (githubToken) {
+      process.env.GITHUB_TOKEN = githubToken;
+      // Don't mask GITHUB_TOKEN — it's already managed by Actions
+    }
+
     // Build config overrides
     const configOverrides: Partial<EvalConfig> = {
       runnerType: runner,

--- a/action/index.ts
+++ b/action/index.ts
@@ -66,7 +66,9 @@ async function run(): Promise<void> {
 
     const githubToken = core.getInput('github-token') || process.env.GITHUB_TOKEN;
     if (githubToken) {
-      process.env.GITHUB_TOKEN = githubToken;
+      // Set COPILOT_GITHUB_TOKEN for the copilot-sdk runner (which ignores
+      // the generic GITHUB_TOKEN since it typically lacks Copilot permissions)
+      process.env.COPILOT_GITHUB_TOKEN = githubToken;
       // Don't mask GITHUB_TOKEN — it's already managed by Actions
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@ai-sdk/anthropic": "^3.0.50",
         "@ai-sdk/google": "^3.0.34",
         "@ai-sdk/openai": "^3.0.33",
+        "@github/copilot-sdk": "^0.2.0",
         "@openai/agents": "^0.4.15",
         "@openrouter/ai-sdk-provider": "^2.2.3",
         "ai": "^6.0.99",
@@ -47,6 +48,9 @@
           "optional": true
         },
         "@ai-sdk/openai": {
+          "optional": true
+        },
+        "@github/copilot-sdk": {
           "optional": true
         },
         "@openai/agents": {
@@ -721,6 +725,143 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.10.tgz",
+      "integrity": "sha512-RpHYMXYpyAgQLYQ3MB8ubV8zMn/zDatwaNmdxcC8ws7jqM+Ojy7Dz4KFKzyT0rCrWoUCAEBXsXoPbP0LY0FgLw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.10",
+        "@github/copilot-darwin-x64": "1.0.10",
+        "@github/copilot-linux-arm64": "1.0.10",
+        "@github/copilot-linux-x64": "1.0.10",
+        "@github/copilot-win32-arm64": "1.0.10",
+        "@github/copilot-win32-x64": "1.0.10"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.10.tgz",
+      "integrity": "sha512-MNlzwkTQ9iUgHQ+2Z25D0KgYZDEl4riEa1Z4/UCNpHXmmBiIY8xVRbXZTNMB69cnagjQ5Z8D2QM2BjI0kqeFPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.10.tgz",
+      "integrity": "sha512-zAQBCbEue/n4xHBzE9T03iuupVXvLtu24MDMeXXtIC0d4O+/WV6j1zVJrp9Snwr0MBWYH+wUrV74peDDdd1VOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.10.tgz",
+      "integrity": "sha512-7mJ3uLe7ITyRi2feM1rMLQ5d0bmUGTUwV1ZxKZwSzWCYmuMn05pg4fhIUdxZZZMkLbOl3kG/1J7BxMCTdS2w7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.10.tgz",
+      "integrity": "sha512-66NPaxroRScNCs6TZGX3h1RSKtzew0tcHBkj4J1AHkgYLjNHMdjjBwokGtKeMxzYOCAMBbmJkUDdNGkqsKIKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.0.tgz",
+      "integrity": "sha512-fCEpD9W9xqcaCAJmatyNQ1PkET9P9liK2P4Vk0raDFoMXcvpIdqewa5JQeKtWCBUsN/HCz7ExkkFP8peQuo+DA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@github/copilot": "^1.0.10",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.10.tgz",
+      "integrity": "sha512-WC5M+M75sxLn4lvZ1wPA1Lrs/vXFisPXJPCKbKOMKqzwMLX/IbuybTV4dZDIyGEN591YmOdRIylUF0tVwO8Zmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.10.tgz",
+      "integrity": "sha512-tUfIwyamd0zpm9DVTtbjIWF6j3zrA5A5IkkiuRgsy0HRJPQpeAV7ZYaHEZteHrynaULpl1Gn/Dq0IB4hYc4QtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@hono/node-server": {
@@ -3558,6 +3699,17 @@
         }
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3624,9 +3776,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.4.tgz",
-      "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "bundle:action": "npm run build && esbuild dist/action/index.js --bundle --platform=node --target=node20 --format=cjs --outfile=action/dist/index.cjs --external:@openai/agents --external:openai --external:ai --external:@ai-sdk/* --external:@openrouter/* --external:zod"
+    "bundle:action": "npm run build && esbuild dist/action/index.js --bundle --platform=node --target=node20 --format=cjs --outfile=action/dist/index.cjs --external:@openai/agents --external:openai --external:ai --external:@ai-sdk/* --external:@openrouter/* --external:zod --external:@github/copilot-sdk"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "~0.1.76",
@@ -62,7 +62,8 @@
     "@openrouter/ai-sdk-provider": "^2.2.3",
     "ai": "^6.0.99",
     "openai": "^6.25.0",
-    "zod": "^4.0.0"
+    "zod": "^4.0.0",
+    "@github/copilot-sdk": ">=0.1.0"
   },
   "peerDependenciesMeta": {
     "ai": {
@@ -87,6 +88,9 @@
       "optional": true
     },
     "zod": {
+      "optional": true
+    },
+    "@github/copilot-sdk": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -58,12 +58,12 @@
     "@ai-sdk/anthropic": "^3.0.50",
     "@ai-sdk/google": "^3.0.34",
     "@ai-sdk/openai": "^3.0.33",
+    "@github/copilot-sdk": "^0.2.0",
     "@openai/agents": "^0.4.15",
     "@openrouter/ai-sdk-provider": "^2.2.3",
     "ai": "^6.0.99",
     "openai": "^6.25.0",
-    "zod": "^4.0.0",
-    "@github/copilot-sdk": ">=0.1.0"
+    "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "ai": {

--- a/src/__tests__/copilot-sdk-runner.test.ts
+++ b/src/__tests__/copilot-sdk-runner.test.ts
@@ -441,6 +441,21 @@ describe('CopilotSdkRunner', () => {
     // Non-write requests should always be approved
     expect(handler({ kind: 'read', path: deniedPath }))
       .toEqual({ kind: 'approved' });
+
+    // Fail-closed: writes with unknown path shapes are denied
+    expect(handler({ kind: 'write' }))
+      .toEqual({ kind: 'denied' });
+    expect(handler({ kind: 'write', target: allowedPath }))
+      .toEqual({ kind: 'denied' });
+  });
+
+  it('defaults numTurns to 1 when sendAndWait returns content without events', async () => {
+    // sendAndWait returns output directly; no assistant.message events emitted.
+    const result = await runner.runTask(mockTask);
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toBe('Hello!');
+    expect(result.numTurns).toBe(1);
   });
 
   it('does not set skillDirectories when skillsDir is not provided', async () => {

--- a/src/__tests__/copilot-sdk-runner.test.ts
+++ b/src/__tests__/copilot-sdk-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CopilotSdkRunner } from '../runner/copilot-sdk-runner.js';
 import type { EvalTask } from '../types.js';
 
@@ -252,6 +252,19 @@ describe('CopilotSdkRunner', () => {
     expect(mocks.stop).toHaveBeenCalledOnce();
   });
 
+  it('dispose cleans up temp config directory', async () => {
+    await runner.runTask(mockTask);
+
+    // Verify configDir was created
+    const configDir = (runner as any).configDir;
+    expect(configDir).toBeTruthy();
+
+    await runner.dispose();
+
+    // Verify configDir was cleaned up
+    expect((runner as any).configDir).toBeNull();
+  });
+
   it('falls back to textChunks when sendAndWait returns no content', async () => {
     mocks.createSession.mockImplementation(async (config: any) => {
       const session = {
@@ -269,6 +282,127 @@ describe('CopilotSdkRunner', () => {
 
     const result = await runner.runTask(mockTask);
     expect(result.output).toBe('Streamed response');
+  });
+
+  describe('BYOK auto-detection from environment variables', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+      delete process.env.OPENAI_API_KEY;
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.COPILOT_GITHUB_TOKEN;
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('auto-detects OpenAI provider for non-claude model with OPENAI_API_KEY', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test-openai';
+      const autoMocks = createMocks();
+      const autoRunner = new TestableCopilotSdkRunner({
+        cwd: '/tmp/test',
+        model: 'gpt-5',
+      });
+      autoRunner.mockModules = { '@github/copilot-sdk': autoMocks.sdkModule };
+
+      await autoRunner.runTask(mockTask);
+
+      const sessionConfig = autoMocks.createSession.mock.calls[0][0];
+      expect(sessionConfig.provider).toEqual({
+        type: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test-openai',
+      });
+    });
+
+    it('auto-detects Anthropic provider for claude model with ANTHROPIC_API_KEY', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test-anthropic';
+      const autoMocks = createMocks();
+      const autoRunner = new TestableCopilotSdkRunner({
+        cwd: '/tmp/test',
+        model: 'claude-sonnet-4-6',
+      });
+      autoRunner.mockModules = { '@github/copilot-sdk': autoMocks.sdkModule };
+
+      await autoRunner.runTask(mockTask);
+
+      const sessionConfig = autoMocks.createSession.mock.calls[0][0];
+      expect(sessionConfig.provider).toEqual({
+        type: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        apiKey: 'sk-test-anthropic',
+      });
+    });
+
+    it('falls back to OpenAI key for claude model when no Anthropic key', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test-openai';
+      const autoMocks = createMocks();
+      const autoRunner = new TestableCopilotSdkRunner({
+        cwd: '/tmp/test',
+        model: 'claude-sonnet-4-6',
+      });
+      autoRunner.mockModules = { '@github/copilot-sdk': autoMocks.sdkModule };
+
+      await autoRunner.runTask(mockTask);
+
+      const sessionConfig = autoMocks.createSession.mock.calls[0][0];
+      expect(sessionConfig.provider).toEqual({
+        type: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test-openai',
+      });
+    });
+
+    it('falls back to Anthropic key for non-claude model when no OpenAI key', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test-anthropic';
+      const autoMocks = createMocks();
+      const autoRunner = new TestableCopilotSdkRunner({
+        cwd: '/tmp/test',
+        model: 'gpt-5',
+      });
+      autoRunner.mockModules = { '@github/copilot-sdk': autoMocks.sdkModule };
+
+      await autoRunner.runTask(mockTask);
+
+      const sessionConfig = autoMocks.createSession.mock.calls[0][0];
+      expect(sessionConfig.provider).toEqual({
+        type: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        apiKey: 'sk-test-anthropic',
+      });
+    });
+
+    it('does not set provider when no API keys are available', async () => {
+      const autoMocks = createMocks();
+      const autoRunner = new TestableCopilotSdkRunner({
+        cwd: '/tmp/test',
+        model: 'gpt-5',
+      });
+      autoRunner.mockModules = { '@github/copilot-sdk': autoMocks.sdkModule };
+
+      await autoRunner.runTask(mockTask);
+
+      const sessionConfig = autoMocks.createSession.mock.calls[0][0];
+      expect(sessionConfig.provider).toBeUndefined();
+    });
+
+    it('skips auto-detection when Copilot token is set', async () => {
+      process.env.COPILOT_GITHUB_TOKEN = 'ghp-test-token';
+      process.env.OPENAI_API_KEY = 'sk-test-openai';
+      const autoMocks = createMocks();
+      const autoRunner = new TestableCopilotSdkRunner({
+        cwd: '/tmp/test',
+        model: 'gpt-5',
+      });
+      autoRunner.mockModules = { '@github/copilot-sdk': autoMocks.sdkModule };
+
+      await autoRunner.runTask(mockTask);
+
+      const sessionConfig = autoMocks.createSession.mock.calls[0][0];
+      expect(sessionConfig.provider).toBeUndefined();
+    });
   });
 
   it('does not set skillDirectories when skillsDir is not provided', async () => {

--- a/src/__tests__/copilot-sdk-runner.test.ts
+++ b/src/__tests__/copilot-sdk-runner.test.ts
@@ -58,7 +58,6 @@ function createMocks(overrides: {
 
   const sdkModule = {
     CopilotClient: CopilotClientClass,
-    approveAll: () => ({ kind: 'approved' as const }),
   };
 
   return { session, start, stop, createSession, sdkModule };
@@ -201,6 +200,8 @@ describe('CopilotSdkRunner', () => {
     expect(result.errorMessage).toContain('Connection lost');
     expect(result.taskId).toBe('test-1');
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    // Verify session cleanup on error path
+    expect(mocks.session.disconnect).toHaveBeenCalledOnce();
   });
 
   it('returns error result when dynamic import fails', async () => {
@@ -256,13 +257,19 @@ describe('CopilotSdkRunner', () => {
   it('dispose cleans up temp config directory', async () => {
     await runner.runTask(mockTask);
 
-    // Verify configDir was created
+    // Verify configDir was created (a real temp directory via mkdtempSync)
     const configDir = (runner as any).configDir;
     expect(configDir).toBeTruthy();
 
+    // Verify the temp directory actually exists on disk
+    const { existsSync } = await import('fs');
+    expect(existsSync(configDir)).toBe(true);
+
     await runner.dispose();
 
-    // Verify configDir was cleaned up
+    // Verify the temp directory was removed from disk
+    expect(existsSync(configDir)).toBe(false);
+    // Verify configDir was nulled
     expect((runner as any).configDir).toBeNull();
   });
 

--- a/src/__tests__/copilot-sdk-runner.test.ts
+++ b/src/__tests__/copilot-sdk-runner.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CopilotSdkRunner } from '../runner/copilot-sdk-runner.js';
+import type { EvalTask } from '../types.js';
+
+const mockTask: EvalTask = {
+  id: 'test-1',
+  prompt: 'Say hello',
+  expectedSkillLoad: 'greeting',
+  criteria: [{ dimension: 'discovery', weight: 0.3, description: 'test' }],
+  goldenChecklist: ['Says hello'],
+};
+
+/**
+ * Testable subclass that overrides dynamicImport to inject mock modules
+ * and exposes the internal client for assertions.
+ */
+class TestableCopilotSdkRunner extends CopilotSdkRunner {
+  public mockModules: Record<string, any> = {};
+
+  protected override async dynamicImport(pkg: string, _hint: string): Promise<any> {
+    if (this.mockModules[pkg]) return this.mockModules[pkg];
+    throw new Error(`Module "${pkg}" not available`);
+  }
+
+  /** Expose internal client for test assertions. */
+  get _client(): any {
+    return (this as any).client;
+  }
+}
+
+/** Create mock session/client functions. */
+function createMocks(overrides: {
+  sendResult?: any;
+  sendError?: Error;
+} = {}) {
+  const session = {
+    sendAndWait: vi.fn(async () => {
+      if (overrides.sendError) throw overrides.sendError;
+      return overrides.sendResult ?? {
+        type: 'assistant.message',
+        data: { content: 'Hello!' },
+      };
+    }),
+    disconnect: vi.fn(async () => {}),
+  };
+
+  const start = vi.fn(async () => {});
+  const stop = vi.fn(async () => {});
+  const createSession = vi.fn(async () => session);
+
+  // Use a proper function constructor so `new` works
+  const CopilotClientClass = function CopilotClient(this: any) {
+    this.start = start;
+    this.stop = stop;
+    this.createSession = createSession;
+  };
+
+  const sdkModule = {
+    CopilotClient: CopilotClientClass,
+    approveAll: () => ({ kind: 'approved' as const }),
+  };
+
+  return { session, start, stop, createSession, sdkModule };
+}
+
+describe('CopilotSdkRunner', () => {
+  let runner: TestableCopilotSdkRunner;
+  let mocks: ReturnType<typeof createMocks>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks = createMocks();
+    runner = new TestableCopilotSdkRunner({
+      cwd: '/tmp/test',
+      model: 'gpt-5',
+      skillsDir: '/skills',
+    });
+    runner.mockModules = {
+      '@github/copilot-sdk': mocks.sdkModule,
+    };
+  });
+
+  it('has correct provider name', () => {
+    expect(runner.providerName).toBe('copilot-sdk');
+  });
+
+  it('creates client and session', async () => {
+    await runner.runTask(mockTask);
+
+    expect(mocks.start).toHaveBeenCalledOnce();
+    expect(mocks.createSession).toHaveBeenCalledOnce();
+
+    const sessionConfig = mocks.createSession.mock.calls[0][0];
+    expect(sessionConfig.model).toBe('gpt-5');
+    expect(sessionConfig.workingDirectory).toBe('/tmp/test');
+    expect(sessionConfig.skillDirectories).toEqual(['/skills']);
+    expect(sessionConfig.onPermissionRequest).toBeDefined();
+    expect(sessionConfig.hooks).toBeDefined();
+    expect(sessionConfig.onEvent).toBeDefined();
+  });
+
+  it('returns successful result with output', async () => {
+    const result = await runner.runTask(mockTask);
+
+    expect(result.isError).toBe(false);
+    expect(result.taskId).toBe('test-1');
+    expect(result.output).toBe('Hello!');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    expect(result.costUsd).toBe(0);
+  });
+
+  it('sends task prompt via sendAndWait', async () => {
+    await runner.runTask(mockTask);
+
+    expect(mocks.session.sendAndWait).toHaveBeenCalledOnce();
+    const [options, timeout] = mocks.session.sendAndWait.mock.calls[0];
+    expect(options.prompt).toBe('Say hello');
+    expect(timeout).toBe(300000);
+  });
+
+  it('disconnects session after task', async () => {
+    await runner.runTask(mockTask);
+    expect(mocks.session.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('tracks tool calls from onPostToolUse hook', async () => {
+    mocks.createSession.mockImplementation(async (config: any) => {
+      const session = {
+        sendAndWait: vi.fn(async () => {
+          config.hooks.onPostToolUse({
+            toolName: 'Read',
+            toolArgs: { file_path: '/tmp/test/file.txt' },
+            toolResult: { textResultForLlm: 'file content', resultType: 'success' },
+          });
+          config.hooks.onPostToolUse({
+            toolName: 'Bash',
+            toolArgs: { command: 'echo hi' },
+            toolResult: { textResultForLlm: 'hi', resultType: 'success' },
+          });
+          return { type: 'assistant.message', data: { content: 'Done!' } };
+        }),
+        disconnect: vi.fn(async () => {}),
+      };
+      return session;
+    });
+
+    const result = await runner.runTask(mockTask);
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls[0].tool).toBe('Read');
+    expect(result.toolCalls[1].tool).toBe('Bash');
+  });
+
+  it('detects skill loads from skill.invoked events', async () => {
+    mocks.createSession.mockImplementation(async (config: any) => {
+      const session = {
+        sendAndWait: vi.fn(async () => {
+          config.onEvent({
+            type: 'skill.invoked',
+            data: { name: 'greeting', path: '/skills/greeting/SKILL.md' },
+          });
+          return { type: 'assistant.message', data: { content: 'Hello!' } };
+        }),
+        disconnect: vi.fn(async () => {}),
+      };
+      return session;
+    });
+
+    const result = await runner.runTask(mockTask);
+    expect(result.skillLoads).toContain('greeting');
+  });
+
+  it('deduplicates skill loads', async () => {
+    mocks.createSession.mockImplementation(async (config: any) => {
+      const session = {
+        sendAndWait: vi.fn(async () => {
+          config.onEvent({
+            type: 'skill.invoked',
+            data: { name: 'greeting', path: '/skills/greeting/SKILL.md' },
+          });
+          config.onEvent({
+            type: 'skill.invoked',
+            data: { name: 'greeting', path: '/skills/greeting/SKILL.md' },
+          });
+          return { type: 'assistant.message', data: { content: 'Hello!' } };
+        }),
+        disconnect: vi.fn(async () => {}),
+      };
+      return session;
+    });
+
+    const result = await runner.runTask(mockTask);
+    expect(result.skillLoads).toEqual(['greeting']);
+  });
+
+  it('returns error result on sendAndWait failure', async () => {
+    mocks.session.sendAndWait.mockRejectedValue(new Error('Connection lost'));
+
+    const result = await runner.runTask(mockTask);
+    expect(result.isError).toBe(true);
+    expect(result.errorMessage).toContain('Connection lost');
+    expect(result.taskId).toBe('test-1');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns error result when dynamic import fails', async () => {
+    runner.mockModules = {}; // No modules available
+
+    const result = await runner.runTask(mockTask);
+    expect(result.isError).toBe(true);
+    expect(result.errorMessage).toContain('not available');
+  });
+
+  it('passes provider config for BYOK', async () => {
+    const byokMocks = createMocks();
+    runner = new TestableCopilotSdkRunner({
+      cwd: '/tmp/test',
+      model: 'gpt-5',
+      provider: {
+        type: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+      },
+    });
+    runner.mockModules = {
+      '@github/copilot-sdk': byokMocks.sdkModule,
+    };
+
+    await runner.runTask(mockTask);
+
+    const sessionConfig = byokMocks.createSession.mock.calls[0][0];
+    expect(sessionConfig.provider).toEqual({
+      type: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-test',
+    });
+  });
+
+  it('reuses client across multiple tasks', async () => {
+    await runner.runTask(mockTask);
+    await runner.runTask({ ...mockTask, id: 'test-2' });
+
+    // Client should only be started once (lazy singleton)
+    expect(mocks.start).toHaveBeenCalledOnce();
+    // But sessions are created per task
+    expect(mocks.createSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('dispose stops the client', async () => {
+    await runner.runTask(mockTask);
+    await runner.dispose();
+
+    expect(mocks.stop).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to textChunks when sendAndWait returns no content', async () => {
+    mocks.createSession.mockImplementation(async (config: any) => {
+      const session = {
+        sendAndWait: vi.fn(async () => {
+          config.onEvent({
+            type: 'assistant.message',
+            data: { content: 'Streamed response' },
+          });
+          return undefined; // No response from sendAndWait
+        }),
+        disconnect: vi.fn(async () => {}),
+      };
+      return session;
+    });
+
+    const result = await runner.runTask(mockTask);
+    expect(result.output).toBe('Streamed response');
+  });
+
+  it('does not set skillDirectories when skillsDir is not provided', async () => {
+    runner = new TestableCopilotSdkRunner({
+      cwd: '/tmp/test',
+      model: 'gpt-5',
+    });
+    runner.mockModules = {
+      '@github/copilot-sdk': mocks.sdkModule,
+    };
+
+    await runner.runTask(mockTask);
+
+    const sessionConfig = mocks.createSession.mock.calls[0][0];
+    expect(sessionConfig.skillDirectories).toBeUndefined();
+  });
+});

--- a/src/__tests__/copilot-sdk-runner.test.ts
+++ b/src/__tests__/copilot-sdk-runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
 import { CopilotSdkRunner } from '../runner/copilot-sdk-runner.js';
 import type { EvalTask } from '../types.js';
 
@@ -403,6 +404,36 @@ describe('CopilotSdkRunner', () => {
       const sessionConfig = autoMocks.createSession.mock.calls[0][0];
       expect(sessionConfig.provider).toBeUndefined();
     });
+  });
+
+  it('denies write permission outside allowed directories', async () => {
+    const cwd = path.resolve('/tmp/test');
+    const restrictedMocks = createMocks();
+    const restrictedRunner = new TestableCopilotSdkRunner({
+      cwd,
+      model: 'gpt-5',
+      allowedWriteDirs: ['./results/'],
+    });
+    restrictedRunner.mockModules = { '@github/copilot-sdk': restrictedMocks.sdkModule };
+
+    await restrictedRunner.runTask(mockTask);
+
+    const sessionConfig = restrictedMocks.createSession.mock.calls[0][0];
+    const handler = sessionConfig.onPermissionRequest;
+
+    // Write inside allowed dir should be approved
+    const allowedPath = path.resolve(cwd, 'results', 'output.json');
+    expect(handler({ kind: 'write', path: allowedPath }))
+      .toEqual({ kind: 'approved' });
+
+    // Write outside allowed dir should be denied
+    const deniedPath = path.resolve('/etc/passwd');
+    expect(handler({ kind: 'write', path: deniedPath }))
+      .toEqual({ kind: 'denied' });
+
+    // Non-write requests should always be approved
+    expect(handler({ kind: 'read', path: deniedPath }))
+      .toEqual({ kind: 'approved' });
   });
 
   it('does not set skillDirectories when skillsDir is not provided', async () => {

--- a/src/__tests__/runner-factory.test.ts
+++ b/src/__tests__/runner-factory.test.ts
@@ -21,6 +21,12 @@ describe('createRunner', () => {
     expect(runner.providerName).toBe('openai-agents');
   });
 
+  it('creates a copilot-sdk runner', async () => {
+    const runner = await createRunner('copilot-sdk', {});
+    expect(runner).toBeDefined();
+    expect(runner.providerName).toBe('copilot-sdk');
+  });
+
   it('throws for unknown runner type', async () => {
     await expect(
       createRunner('invalid-runner' as RunnerType, {}),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ program
   .command('run')
   .description('Run the full evaluation pipeline: execute tasks → score → report')
   .argument('<tasks>', 'Path to tasks YAML file')
-  .option('--runner <type>', 'Runner type: claude-sdk, vercel-ai, openai-agents (default: claude-sdk)')
+  .option('--runner <type>', 'Runner type: claude-sdk, vercel-ai, openai-agents, copilot-sdk (default: claude-sdk)')
   .option('--model <model>', 'Agent model (default: sonnet)')
   .option('--judge-model <model>', 'Judge model (default: haiku)')
   .option('--config <path>', 'Path to eval.config.yaml')

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,9 +16,9 @@ import yaml from 'js-yaml';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-export type RunnerType = 'claude-sdk' | 'vercel-ai' | 'openai-agents';
+export type RunnerType = 'claude-sdk' | 'vercel-ai' | 'openai-agents' | 'copilot-sdk';
 
-export const VALID_RUNNER_TYPES: RunnerType[] = ['claude-sdk', 'vercel-ai', 'openai-agents'];
+export const VALID_RUNNER_TYPES: RunnerType[] = ['claude-sdk', 'vercel-ai', 'openai-agents', 'copilot-sdk'];
 
 export interface EvalConfig {
   // Runner

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export { parseEvalFile, createEvalTemplate, validateEvalFile } from './parser.js
 
 // Runner
 export { ClaudeSdkRunner } from './runner/claude-sdk-runner.js';
+export { CopilotSdkRunner } from './runner/copilot-sdk-runner.js';
 export type { AgentRunner, AgentRunnerOptions } from './runner/agent-runner.js';
 export { createRunner } from './runner/runner-factory.js';
 export { setupLocalSkills, cleanupLocalSkills } from './runner/skill-setup.js';

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -159,6 +159,9 @@ async function runPhase(
     );
     allResults.push(results);
 
+    // Dispose runner resources (e.g., child processes) between runs
+    await runner.dispose?.();
+
     if (numRuns > 1) {
       console.log(`\n--- ${phaseLabel}: Scoring Run ${run + 1}/${numRuns} ---\n`);
     } else {
@@ -189,7 +192,7 @@ async function runPhase(
 }
 
 /**
- * Setup local skills for Claude SDK runner.
+ * Setup local skills for Claude SDK and Copilot SDK runners.
  * Returns true if skills were set up and need cleanup.
  */
 async function setupSkills(

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -159,9 +159,6 @@ async function runPhase(
     );
     allResults.push(results);
 
-    // Dispose runner resources (e.g., child processes) between runs
-    await runner.dispose?.();
-
     if (numRuns > 1) {
       console.log(`\n--- ${phaseLabel}: Scoring Run ${run + 1}/${numRuns} ---\n`);
     } else {
@@ -170,6 +167,9 @@ async function runPhase(
     const scores = await scoreAll(evaluation.tasks, results, scorerOptions);
     allScores.push(scores);
   }
+
+  // Dispose runner resources (e.g., child processes) after all runs complete
+  await runner.dispose?.();
 
   const results = aggregateResults(allResults, allScores);
   const scores = aggregateScores(allScores);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -198,7 +198,7 @@ async function setupSkills(
   cwd: string,
 ): Promise<boolean> {
   if (!skillsDir) return false;
-  if (config.runnerType === 'claude-sdk') {
+  if (config.runnerType === 'claude-sdk' || config.runnerType === 'copilot-sdk') {
     console.log(`Setting up local skills from: ${skillsDir}`);
     const skillNames = await setupLocalSkills(skillsDir, cwd);
     console.log(`Skills configured: ${skillNames.join(', ')}`);

--- a/src/runner/agent-runner.ts
+++ b/src/runner/agent-runner.ts
@@ -1,7 +1,7 @@
 /**
  * Agent Runner interface and shared options.
  *
- * All runner implementations (Claude SDK, Vercel AI SDK, OpenAI Agents SDK)
+ * All runner implementations (Claude SDK, Vercel AI SDK, OpenAI Agents SDK, Copilot SDK)
  * implement this interface to produce TaskResult objects consumed by the scorer.
  */
 
@@ -51,7 +51,7 @@ export interface AgentRunnerOptions {
  * 3. Handling skill discovery via the framework's native mechanism
  */
 export interface AgentRunner {
-  /** Human-readable provider name (e.g., 'claude-sdk', 'vercel-ai', 'openai-agents') */
+  /** Human-readable provider name (e.g., 'claude-sdk', 'vercel-ai', 'openai-agents', 'copilot-sdk') */
   readonly providerName: string;
 
   /** Run a single task and produce a TaskResult */
@@ -69,4 +69,7 @@ export interface AgentRunner {
     evaluation: SkillEvaluation,
     createLogger?: (task: EvalTask) => SessionLogger,
   ): Promise<TaskResult[]>;
+
+  /** Release runner resources (e.g., child processes). Called after runAll() completes. */
+  dispose?(): Promise<void>;
 }

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -56,6 +56,11 @@ export class CopilotSdkRunner extends BaseRunner {
       githubToken: options.githubToken,
       provider: options.provider,
     };
+    // Resolve Copilot token eagerly so hasCopilotToken is available
+    // for both client auth (getClient) and BYOK logic (runTask).
+    this.hasCopilotToken = !!(
+      this.sdkOptions.githubToken ?? process.env.COPILOT_GITHUB_TOKEN
+    );
   }
 
   /**
@@ -112,13 +117,28 @@ export class CopilotSdkRunner extends BaseRunner {
 
     if (token) {
       clientOptions.githubToken = token;
-      this.hasCopilotToken = true;
     } else if (!this.sdkOptions.provider) {
-      clientOptions.useLoggedInUser = true;
+      // Only use logged-in user when no BYOK API keys are in the environment.
+      // BYOK auto-detection in runTask() sets a session-level provider that
+      // takes precedence over client auth, but avoiding conflicting configs
+      // is cleaner than relying on that override behavior.
+      const hasApiKeys = !!(process.env.OPENAI_API_KEY || process.env.ANTHROPIC_API_KEY);
+      if (!hasApiKeys) {
+        clientOptions.useLoggedInUser = true;
+      }
     }
 
-    this.client = new sdk.CopilotClient(clientOptions);
-    await this.client.start();
+    try {
+      this.client = new sdk.CopilotClient(clientOptions);
+      await this.client.start();
+    } catch (err) {
+      // Clean up temp dir if client creation fails to prevent orphaned directories
+      try {
+        fs.rmSync(this.configDir, { recursive: true, force: true });
+      } catch { /* ignore cleanup errors */ }
+      this.configDir = null;
+      throw err;
+    }
     return this.client;
   }
 
@@ -182,7 +202,8 @@ export class CopilotSdkRunner extends BaseRunner {
                   skillLoads.push(m[1]);
                 }
               }
-              // Also match standalone skills/<name>/SKILL.md paths
+              // Also match standalone skills/<name>/SKILL.md paths that lack
+              // the .claude/ prefix (e.g., the skillsDir path passed directly)
               const skillMdPattern = /skills\/([^/\s]+)\/SKILL\.md/g;
               while ((m = skillMdPattern.exec(normalized)) !== null) {
                 if (!skillLoads.includes(m[1])) {

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -191,7 +191,11 @@ export class CopilotSdkRunner extends BaseRunner {
           },
         },
 
-        // Event handler for tracking assistant messages + skill invocations
+        // Event handler for tracking assistant messages + skill invocations.
+        // Primary skill detection: skill.invoked events (fires when CLI
+        // natively loads skills via skillDirectories — currently broken in
+        // @github/copilot v1.0.10, see github/copilot-sdk#629).
+        // Fallback: file-browsing detection in onPostToolUse above.
         onEvent: (event: any) => {
           if (event.type === 'assistant.message') {
             const content = event.data?.content ?? '';
@@ -207,7 +211,9 @@ export class CopilotSdkRunner extends BaseRunner {
         },
       };
 
-      // Skill directories for native skill loading (must be absolute)
+      // Skill directories for native skill loading (must be absolute).
+      // When the SDK bug (github/copilot-sdk#629) is fixed, this will
+      // inject skills into the session context and fire skill.invoked events.
       if (this.options.skillsDir) {
         const absSkillsDir = path.isAbsolute(this.options.skillsDir)
           ? this.options.skillsDir

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -46,7 +46,6 @@ export class CopilotSdkRunner extends BaseRunner {
   readonly providerName = 'copilot-sdk';
   private sdkOptions: CopilotSdkRunnerOptions;
   private client: any = null;
-  private hasCopilotToken = false;
   private configDir: string | null = null;
 
   constructor(options: CopilotSdkRunnerOptions = {}, config?: EvalConfig) {
@@ -56,11 +55,11 @@ export class CopilotSdkRunner extends BaseRunner {
       githubToken: options.githubToken,
       provider: options.provider,
     };
-    // Resolve Copilot token eagerly so hasCopilotToken is available
-    // for both client auth (getClient) and BYOK logic (runTask).
-    this.hasCopilotToken = !!(
-      this.sdkOptions.githubToken ?? process.env.COPILOT_GITHUB_TOKEN
-    );
+  }
+
+  /** Check for Copilot token at call time to avoid stale reads. */
+  private get hasCopilotToken(): boolean {
+    return !!(this.sdkOptions.githubToken ?? process.env.COPILOT_GITHUB_TOKEN);
   }
 
   /**
@@ -203,8 +202,10 @@ export class CopilotSdkRunner extends BaseRunner {
                 }
               }
               // Also match standalone skills/<name>/SKILL.md paths that lack
-              // the .claude/ prefix (e.g., the skillsDir path passed directly)
-              const skillMdPattern = /skills\/([^/\s]+)\/SKILL\.md/g;
+              // the .claude/ prefix (e.g., the skillsDir path passed directly).
+              // Require a word boundary or path separator before "skills/" to
+              // avoid matching unrelated directories like "other-skills/".
+              const skillMdPattern = /(?:^|[\s/])skills\/([^/\s]+)\/SKILL\.md/g;
               while ((m = skillMdPattern.exec(normalized)) !== null) {
                 if (!skillLoads.includes(m[1])) {
                   skillLoads.push(m[1]);

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -46,6 +46,7 @@ export class CopilotSdkRunner extends BaseRunner {
   readonly providerName = 'copilot-sdk';
   private sdkOptions: CopilotSdkRunnerOptions;
   private client: any = null;
+  private hasCopilotToken = false;
 
   constructor(options: CopilotSdkRunnerOptions = {}, config?: EvalConfig) {
     super(options, config);
@@ -101,16 +102,16 @@ export class CopilotSdkRunner extends BaseRunner {
       env: isolatedEnv,
     };
 
-    // Auth: explicit token > env vars > logged-in user
+    // Auth: explicit Copilot token > env vars > logged-in user.
+    // Skip the generic GITHUB_TOKEN — it typically lacks Copilot permissions
+    // (e.g., the auto-generated token in GitHub Actions).
     const token = this.sdkOptions.githubToken
-      ?? process.env.COPILOT_GITHUB_TOKEN
-      ?? process.env.GH_TOKEN
-      ?? process.env.GITHUB_TOKEN;
+      ?? process.env.COPILOT_GITHUB_TOKEN;
 
     if (token) {
       clientOptions.githubToken = token;
+      this.hasCopilotToken = true;
     } else if (!this.sdkOptions.provider) {
-      // No token and no BYOK — fall back to logged-in user
       clientOptions.useLoggedInUser = true;
     }
 
@@ -201,9 +202,26 @@ export class CopilotSdkRunner extends BaseRunner {
         sessionConfig.skillDirectories = [absSkillsDir];
       }
 
-      // BYOK provider config
+      // BYOK provider config: explicit > auto-detect from API keys.
+      // Auto-detect enables CI usage without a Copilot-enabled token.
       if (this.sdkOptions.provider) {
         sessionConfig.provider = this.sdkOptions.provider;
+      } else if (!this.hasCopilotToken) {
+        const openaiKey = process.env.OPENAI_API_KEY;
+        const anthropicKey = process.env.ANTHROPIC_API_KEY;
+        if (openaiKey) {
+          sessionConfig.provider = {
+            type: 'openai',
+            baseUrl: 'https://api.openai.com/v1',
+            apiKey: openaiKey,
+          };
+        } else if (anthropicKey) {
+          sessionConfig.provider = {
+            type: 'anthropic',
+            baseUrl: 'https://api.anthropic.com',
+            apiKey: anthropicKey,
+          };
+        }
       }
 
       const session = await client.createSession(sessionConfig);

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -47,6 +47,7 @@ export class CopilotSdkRunner extends BaseRunner {
   private sdkOptions: CopilotSdkRunnerOptions;
   private client: any = null;
   private hasCopilotToken = false;
+  private configDir: string | null = null;
 
   constructor(options: CopilotSdkRunnerOptions = {}, config?: EvalConfig) {
     super(options, config);
@@ -85,7 +86,8 @@ export class CopilotSdkRunner extends BaseRunner {
     // Isolated config directory prevents user-level commands/skills from
     // interfering with evaluation. Override all platform-specific paths
     // (XDG on Linux/macOS, APPDATA/HOME/USERPROFILE on Windows).
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skilljack-copilot-'));
+    this.configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skilljack-copilot-'));
+    const configDir = this.configDir;
     const isolatedEnv: Record<string, string> = {};
     for (const [k, v] of Object.entries(process.env)) {
       if (v) isolatedEnv[k] = v;
@@ -231,29 +233,17 @@ export class CopilotSdkRunner extends BaseRunner {
         const openaiKey = process.env.OPENAI_API_KEY;
         const anthropicKey = process.env.ANTHROPIC_API_KEY;
 
-        if (isAnthropicModel && anthropicKey) {
+        // Prefer the provider matching the model, fall back to whatever key is available
+        const preferredKey = isAnthropicModel ? anthropicKey : openaiKey;
+        const fallbackKey = isAnthropicModel ? openaiKey : anthropicKey;
+        const apiKey = preferredKey ?? fallbackKey;
+
+        if (apiKey) {
+          const useAnthropic = apiKey === anthropicKey;
           sessionConfig.provider = {
-            type: 'anthropic',
-            baseUrl: 'https://api.anthropic.com',
-            apiKey: anthropicKey,
-          };
-        } else if (!isAnthropicModel && openaiKey) {
-          sessionConfig.provider = {
-            type: 'openai',
-            baseUrl: 'https://api.openai.com/v1',
-            apiKey: openaiKey,
-          };
-        } else if (openaiKey) {
-          sessionConfig.provider = {
-            type: 'openai',
-            baseUrl: 'https://api.openai.com/v1',
-            apiKey: openaiKey,
-          };
-        } else if (anthropicKey) {
-          sessionConfig.provider = {
-            type: 'anthropic',
-            baseUrl: 'https://api.anthropic.com',
-            apiKey: anthropicKey,
+            type: useAnthropic ? 'anthropic' : 'openai',
+            baseUrl: useAnthropic ? 'https://api.anthropic.com' : 'https://api.openai.com/v1',
+            apiKey,
           };
         }
       }
@@ -296,7 +286,8 @@ export class CopilotSdkRunner extends BaseRunner {
   }
 
   /**
-   * Stop the shared client. Call after runAll() completes.
+   * Stop the shared client and clean up temp config directory.
+   * Called after runAll() completes.
    */
   async dispose(): Promise<void> {
     if (this.client) {
@@ -306,6 +297,14 @@ export class CopilotSdkRunner extends BaseRunner {
         // Ignore shutdown errors
       }
       this.client = null;
+    }
+    if (this.configDir) {
+      try {
+        fs.rmSync(this.configDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+      this.configDir = null;
     }
   }
 }

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -221,14 +221,29 @@ export class CopilotSdkRunner extends BaseRunner {
         sessionConfig.skillDirectories = [absSkillsDir];
       }
 
-      // BYOK provider config: explicit > auto-detect from API keys.
+      // BYOK provider config: explicit > auto-detect from model + API keys.
       // Auto-detect enables CI usage without a Copilot-enabled token.
       if (this.sdkOptions.provider) {
         sessionConfig.provider = this.sdkOptions.provider;
       } else if (!this.hasCopilotToken) {
+        const model = sessionConfig.model ?? '';
+        const isAnthropicModel = model.startsWith('claude');
         const openaiKey = process.env.OPENAI_API_KEY;
         const anthropicKey = process.env.ANTHROPIC_API_KEY;
-        if (openaiKey) {
+
+        if (isAnthropicModel && anthropicKey) {
+          sessionConfig.provider = {
+            type: 'anthropic',
+            baseUrl: 'https://api.anthropic.com',
+            apiKey: anthropicKey,
+          };
+        } else if (!isAnthropicModel && openaiKey) {
+          sessionConfig.provider = {
+            type: 'openai',
+            baseUrl: 'https://api.openai.com/v1',
+            apiKey: openaiKey,
+          };
+        } else if (openaiKey) {
           sessionConfig.provider = {
             type: 'openai',
             baseUrl: 'https://api.openai.com/v1',

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -16,6 +16,9 @@ import type { AgentRunnerOptions } from './agent-runner.js';
 import type { EvalConfig } from '../config.js';
 import type { SessionLogger } from '../session/session-logger.js';
 import { isWriteAllowed } from './security.js';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
 
 /**
  * BYOK provider config for using your own API key.
@@ -78,8 +81,24 @@ export class CopilotSdkRunner extends BaseRunner {
       '@github/copilot-sdk',
     );
 
+    // Isolated config directory prevents user-level commands/skills from
+    // interfering with evaluation. Override all platform-specific paths
+    // (XDG on Linux/macOS, APPDATA/HOME/USERPROFILE on Windows).
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skilljack-copilot-'));
+    const isolatedEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v) isolatedEnv[k] = v;
+    }
+    isolatedEnv.XDG_CONFIG_HOME = configDir;
+    isolatedEnv.XDG_STATE_HOME = configDir;
+    isolatedEnv.APPDATA = configDir;
+    isolatedEnv.LOCALAPPDATA = configDir;
+    isolatedEnv.HOME = configDir;
+    isolatedEnv.USERPROFILE = configDir;
+
     const clientOptions: Record<string, any> = {
       cwd: this.options.cwd,
+      env: isolatedEnv,
     };
 
     // Auth: explicit token > env vars > logged-in user
@@ -142,6 +161,19 @@ export class CopilotSdkRunner extends BaseRunner {
               input: toolArgs,
             });
             logger?.addToolUse(toolName, toolArgs);
+
+            // Detect skill loads from read/view tool calls to SKILL.md.
+            // Always enabled for copilot-sdk since the CLI uses view/read
+            // tools to access skills (no dedicated Skill tool like Claude SDK).
+            {
+              const filePath: string = toolArgs.path ?? toolArgs.file_path ?? '';
+              if (filePath.includes('SKILL.md') || filePath.includes('/skills/')) {
+                const match = filePath.replace(/\\/g, '/').match(/skills\/([^/]+)/);
+                if (match && !skillLoads.includes(match[1])) {
+                  skillLoads.push(match[1]);
+                }
+              }
+            }
           },
         },
 
@@ -161,9 +193,12 @@ export class CopilotSdkRunner extends BaseRunner {
         },
       };
 
-      // Skill directories for native skill loading
+      // Skill directories for native skill loading (must be absolute)
       if (this.options.skillsDir) {
-        sessionConfig.skillDirectories = [this.options.skillsDir];
+        const absSkillsDir = path.isAbsolute(this.options.skillsDir)
+          ? this.options.skillsDir
+          : path.resolve(cwd, this.options.skillsDir);
+        sessionConfig.skillDirectories = [absSkillsDir];
       }
 
       // BYOK provider config

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -159,11 +159,14 @@ export class CopilotSdkRunner extends BaseRunner {
         model: this.options.model ?? 'gpt-5',
         workingDirectory: cwd,
 
-        // Permission handler: approve reads/shell, restrict writes
+        // Permission handler: approve reads/shell, restrict writes.
+        // Fail-closed: writes with unknown path shapes are denied when
+        // allowedWriteDirs is configured, to avoid bypassing the boundary
+        // if the SDK request shape changes.
         onPermissionRequest: (request: any) => {
           if (request.kind === 'write') {
             const filePath = request.path ?? request.filePath ?? '';
-            if (filePath && !isWriteAllowed(filePath, allowedWriteDirs, cwd)) {
+            if (!filePath || !isWriteAllowed(filePath, allowedWriteDirs, cwd)) {
               return { kind: 'denied' };
             }
           }
@@ -285,12 +288,16 @@ export class CopilotSdkRunner extends BaseRunner {
           logger?.addTextMessage(output);
         }
 
+        // sendAndWait may return content directly without emitting
+        // assistant.message events, leaving numTurns at 0.
+        const effectiveTurns = numTurns === 0 && output ? 1 : numTurns;
+
         return {
           taskId: task.id,
           prompt: task.prompt,
           output,
           durationMs: Date.now() - startTime,
-          numTurns,
+          numTurns: effectiveTurns,
           costUsd: 0, // Copilot SDK doesn't expose per-token cost
           skillLoads: [...new Set(skillLoads)],
           toolCalls,

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -1,0 +1,224 @@
+/**
+ * GitHub Copilot SDK Runner
+ *
+ * Runs evaluation tasks using the GitHub Copilot SDK's agentic engine.
+ * Communicates with the Copilot CLI via JSON-RPC (stdio transport).
+ *
+ * Supports GitHub token auth or BYOK (Bring Your Own Key) with
+ * OpenAI, Anthropic, or Azure providers.
+ *
+ * @see https://github.com/github/copilot-sdk
+ */
+
+import type { EvalTask, ToolCallRecord, TaskResult } from '../types.js';
+import { BaseRunner } from './base-runner.js';
+import type { AgentRunnerOptions } from './agent-runner.js';
+import type { EvalConfig } from '../config.js';
+import type { SessionLogger } from '../session/session-logger.js';
+import { isWriteAllowed } from './security.js';
+
+/**
+ * BYOK provider config for using your own API key.
+ */
+export interface CopilotProviderConfig {
+  type?: 'openai' | 'azure' | 'anthropic';
+  baseUrl: string;
+  apiKey?: string;
+}
+
+/**
+ * Copilot SDK-specific options (extends shared options).
+ */
+export interface CopilotSdkRunnerOptions extends AgentRunnerOptions {
+  /** GitHub token for Copilot authentication. */
+  githubToken?: string;
+  /**
+   * BYOK provider config. When set, uses your own API key instead of GitHub auth.
+   * @example { type: 'openai', baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-...' }
+   */
+  provider?: CopilotProviderConfig;
+}
+
+export class CopilotSdkRunner extends BaseRunner {
+  readonly providerName = 'copilot-sdk';
+  private sdkOptions: CopilotSdkRunnerOptions;
+  private client: any = null;
+
+  constructor(options: CopilotSdkRunnerOptions = {}, config?: EvalConfig) {
+    super(options, config);
+    this.sdkOptions = {
+      ...this.options,
+      githubToken: options.githubToken,
+      provider: options.provider,
+    };
+  }
+
+  /**
+   * Dynamically import a module, throwing a helpful error if missing.
+   * Protected to allow test subclasses to inject mocks.
+   */
+  protected async dynamicImport(pkg: string, installHint: string): Promise<any> {
+    try {
+      return await (Function('pkg', 'return import(pkg)')(pkg));
+    } catch (err) {
+      const detail = err instanceof Error ? `: ${err.message}` : '';
+      throw new Error(`${pkg} is required${detail}. Install with: npm install ${installHint}`);
+    }
+  }
+
+  /**
+   * Get or create a lazy CopilotClient singleton.
+   * Reused across tasks to avoid per-task server startup overhead.
+   */
+  private async getClient(): Promise<any> {
+    if (this.client) return this.client;
+
+    const sdk = await this.dynamicImport(
+      '@github/copilot-sdk',
+      '@github/copilot-sdk',
+    );
+
+    const clientOptions: Record<string, any> = {
+      cwd: this.options.cwd,
+    };
+
+    // Auth: explicit token > env vars > logged-in user
+    const token = this.sdkOptions.githubToken
+      ?? process.env.COPILOT_GITHUB_TOKEN
+      ?? process.env.GH_TOKEN
+      ?? process.env.GITHUB_TOKEN;
+
+    if (token) {
+      clientOptions.githubToken = token;
+    } else if (!this.sdkOptions.provider) {
+      // No token and no BYOK — fall back to logged-in user
+      clientOptions.useLoggedInUser = true;
+    }
+
+    this.client = new sdk.CopilotClient(clientOptions);
+    await this.client.start();
+    return this.client;
+  }
+
+  async runTask(task: EvalTask, logger?: SessionLogger): Promise<TaskResult> {
+    const skillLoads: string[] = [];
+    const toolCalls: ToolCallRecord[] = [];
+    const textChunks: string[] = [];
+    let numTurns = 0;
+    const startTime = Date.now();
+
+    try {
+      const client = await this.getClient();
+
+      const cwd = this.options.cwd ?? process.cwd();
+      const allowedWriteDirs = this.options.allowedWriteDirs ?? [];
+
+      // Build session config
+      const sessionConfig: Record<string, any> = {
+        model: this.options.model ?? 'gpt-5',
+        workingDirectory: cwd,
+
+        // Permission handler: approve reads/shell, restrict writes
+        onPermissionRequest: (request: any) => {
+          if (request.kind === 'write') {
+            const filePath = request.path ?? request.filePath ?? '';
+            if (filePath && !isWriteAllowed(filePath, allowedWriteDirs, cwd)) {
+              return { kind: 'denied' };
+            }
+          }
+          return { kind: 'approved' };
+        },
+
+        // Hooks for tool call tracking + skill detection
+        hooks: {
+          onPostToolUse: (input: any) => {
+            const toolName = input.toolName ?? '';
+            const toolArgs = input.toolArgs ?? {};
+
+            toolCalls.push({
+              tool: toolName,
+              toolUseId: `copilot-${toolCalls.length}`,
+              timestamp: Date.now(),
+              input: toolArgs,
+            });
+            logger?.addToolUse(toolName, toolArgs);
+          },
+        },
+
+        // Event handler for tracking assistant messages + skill invocations
+        onEvent: (event: any) => {
+          if (event.type === 'assistant.message') {
+            const content = event.data?.content ?? '';
+            textChunks.push(content);
+            numTurns++;
+            logger?.addAssistantMessage([{ type: 'text', text: content }]);
+          } else if (event.type === 'skill.invoked') {
+            const skillName = event.data?.name;
+            if (skillName && !skillLoads.includes(skillName)) {
+              skillLoads.push(skillName);
+            }
+          }
+        },
+      };
+
+      // Skill directories for native skill loading
+      if (this.options.skillsDir) {
+        sessionConfig.skillDirectories = [this.options.skillsDir];
+      }
+
+      // BYOK provider config
+      if (this.sdkOptions.provider) {
+        sessionConfig.provider = this.sdkOptions.provider;
+      }
+
+      const session = await client.createSession(sessionConfig);
+
+      try {
+        // Send task and wait for completion
+        const timeout = this.options.taskTimeoutMs ?? 300000;
+        const response = await session.sendAndWait(
+          { prompt: task.prompt },
+          timeout,
+        );
+
+        const output = response?.data?.content ?? textChunks.join('\n');
+        if (output && textChunks.length === 0) {
+          logger?.addTextMessage(output);
+        }
+
+        return {
+          taskId: task.id,
+          prompt: task.prompt,
+          output,
+          durationMs: Date.now() - startTime,
+          numTurns,
+          costUsd: 0, // Copilot SDK doesn't expose per-token cost
+          skillLoads: [...new Set(skillLoads)],
+          toolCalls,
+          isError: false,
+          errorMessage: '',
+        };
+      } finally {
+        await session.disconnect();
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger?.markAsError(errorMessage);
+      return this.createErrorResult(task, errorMessage, Date.now() - startTime);
+    }
+  }
+
+  /**
+   * Stop the shared client. Call after runAll() completes.
+   */
+  async dispose(): Promise<void> {
+    if (this.client) {
+      try {
+        await this.client.stop();
+      } catch {
+        // Ignore shutdown errors
+      }
+      this.client = null;
+    }
+  }
+}

--- a/src/runner/copilot-sdk-runner.ts
+++ b/src/runner/copilot-sdk-runner.ts
@@ -163,15 +163,28 @@ export class CopilotSdkRunner extends BaseRunner {
             });
             logger?.addToolUse(toolName, toolArgs);
 
-            // Detect skill loads from read/view tool calls to SKILL.md.
-            // Always enabled for copilot-sdk since the CLI uses view/read
-            // tools to access skills (no dedicated Skill tool like Claude SDK).
+            // Detect skill loads from tool calls that access SKILL.md.
+            // Check both tool args (view/read path) and tool result text
+            // (grep/glob results that reference skill files).
             {
               const filePath: string = toolArgs.path ?? toolArgs.file_path ?? '';
-              if (filePath.includes('SKILL.md') || filePath.includes('/skills/')) {
-                const match = filePath.replace(/\\/g, '/').match(/skills\/([^/]+)/);
-                if (match && !skillLoads.includes(match[1])) {
-                  skillLoads.push(match[1]);
+              const resultText: string = input.toolResult?.textResultForLlm ?? '';
+              const combined = filePath + '\n' + resultText;
+              const normalized = combined.replace(/\\/g, '/');
+
+              // Match all occurrences of skills/<name> in args or results
+              const skillPattern = /[/.]claude\/skills\/([^/\s]+)/g;
+              let m;
+              while ((m = skillPattern.exec(normalized)) !== null) {
+                if (!skillLoads.includes(m[1])) {
+                  skillLoads.push(m[1]);
+                }
+              }
+              // Also match standalone skills/<name>/SKILL.md paths
+              const skillMdPattern = /skills\/([^/\s]+)\/SKILL\.md/g;
+              while ((m = skillMdPattern.exec(normalized)) !== null) {
+                if (!skillLoads.includes(m[1])) {
+                  skillLoads.push(m[1]);
                 }
               }
             }

--- a/src/runner/runner-factory.ts
+++ b/src/runner/runner-factory.ts
@@ -13,7 +13,7 @@ import type { RunnerType, EvalConfig } from '../config.js';
 /**
  * Create the appropriate AgentRunner based on runner type.
  *
- * @param type - Runner type ('claude-sdk', 'vercel-ai', or 'openai-agents')
+ * @param type - Runner type ('claude-sdk', 'vercel-ai', 'openai-agents', or 'copilot-sdk')
  * @param options - Runner options (cwd, model, timeout, etc.)
  * @param config - Optional pre-loaded EvalConfig. Passed through to BaseRunner
  *   so YAML file config values are respected. When omitted, BaseRunner falls
@@ -46,6 +46,16 @@ export async function createRunner(
         );
       });
       return new OpenAiAgentsRunner(options, config);
+    }
+
+    case 'copilot-sdk': {
+      const { CopilotSdkRunner } = await import('./copilot-sdk-runner.js').catch(() => {
+        throw new Error(
+          'Copilot SDK runner requires "@github/copilot-sdk". ' +
+          'Install it with: npm install @github/copilot-sdk',
+        );
+      });
+      return new CopilotSdkRunner(options, config);
     }
 
     default:


### PR DESCRIPTION
## Summary

- Adds `copilot-sdk` as the fourth runner option using the open-source `@github/copilot-sdk` package
- Follows existing runner architecture: extends `BaseRunner`, dynamic import in factory, optional peer dependency
- Supports GitHub token auth (`COPILOT_GITHUB_TOKEN`/`GH_TOKEN`/`GITHUB_TOKEN`) or BYOK with OpenAI/Anthropic/Azure API keys
- Detects skill activation via native `skill.invoked` session events, tracks tool calls via `onPostToolUse` hooks
- 15 unit tests with full coverage of client lifecycle, skill detection, tool tracking, BYOK, and error handling

## Files changed

| File | Change |
|------|--------|
| `src/runner/copilot-sdk-runner.ts` | **New** — core runner (lazy client singleton, permission handler, event tracking) |
| `src/__tests__/copilot-sdk-runner.test.ts` | **New** — 15 unit tests |
| `src/config.ts` | Add `'copilot-sdk'` to `RunnerType` union |
| `src/runner/runner-factory.ts` | Add dynamic import case with install hint |
| `src/cli.ts` | Update `--runner` help text |
| `src/index.ts` | Add public export |
| `src/pipeline.ts` | Include copilot-sdk in skill setup (`.claude/skills/` copy) |
| `package.json` | Add optional peer dep + esbuild external |
| `CLAUDE.md` | Document new runner, auth, and dependency |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` compiles cleanly
- [x] `npm run test` — all 193 tests pass (15 new + 178 existing)
- [ ] Manual smoke test with `@github/copilot-sdk` installed + GitHub token

🤖 Generated with [Claude Code](https://claude.com/claude-code)