### PR TITLE
Fix GitHub summary hardcoded pass/fail thresholds

### DIFF
--- a/src/__tests__/github-summary.test.ts
+++ b/src/__tests__/github-summary.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateGitHubSummary } from '../report/github-summary.js';
+import { DEFAULT_CONFIG } from '../config.js';
+import type { EvalConfig } from '../config.js';
 import type { EvaluationReport } from '../types.js';
 
 function makeReport(overrides: Partial<EvaluationReport> = {}): EvaluationReport {
@@ -188,5 +190,67 @@ describe('generateGitHubSummary', () => {
     expect(summary).toContain('- FAIL: No evidence item');
     // Should not have a trailing dash for missing evidence
     expect(summary).not.toContain('— ');
+  });
+
+  it('uses custom thresholds from config', () => {
+    const customConfig: EvalConfig = { ...DEFAULT_CONFIG, discoveryThreshold: 0.5, scoreThreshold: 3.0 };
+    const report = makeReport({
+      passed: true,
+      summary: {
+        totalTasks: 2,
+        numRuns: 1,
+        discoveryAccuracy: 0.6,
+        avgAdherence: 3.5,
+        avgOutputQuality: 3.5,
+        avgWeightedScore: 0.6,
+        totalDurationMs: 2000,
+        totalCostUsd: 0.02,
+      },
+    });
+
+    const summary = generateGitHubSummary(report, customConfig);
+
+    // These would be FAIL with default thresholds (0.8 / 4.0) but PASS with custom (0.5 / 3.0)
+    expect(summary).toContain('| Discovery Rate | 60%');
+    expect(summary).toContain('PASS');
+    expect(summary).not.toMatch(/Discovery Rate.*FAIL/);
+    expect(summary).not.toMatch(/Avg Adherence.*FAIL/);
+    expect(summary).not.toMatch(/Avg Output Quality.*FAIL/);
+  });
+
+  it('displays threshold column with configured values', () => {
+    const customConfig: EvalConfig = { ...DEFAULT_CONFIG, discoveryThreshold: 0.7, scoreThreshold: 3.5 };
+    const report = makeReport();
+
+    const summary = generateGitHubSummary(report, customConfig);
+
+    expect(summary).toContain('| Metric | Value | Threshold | Status |');
+    expect(summary).toMatch(/Discovery Rate.*70%/);
+    expect(summary).toMatch(/Avg Adherence.*3\.5/);
+    expect(summary).toMatch(/Avg Output Quality.*3\.5/);
+  });
+
+  it('passes at exact threshold boundary (>=)', () => {
+    const customConfig: EvalConfig = { ...DEFAULT_CONFIG, discoveryThreshold: 0.6, scoreThreshold: 3.0 };
+    const report = makeReport({
+      passed: true,
+      summary: {
+        totalTasks: 5,
+        numRuns: 1,
+        discoveryAccuracy: 0.6,
+        avgAdherence: 3.0,
+        avgOutputQuality: 3.0,
+        avgWeightedScore: 0.5,
+        totalDurationMs: 1000,
+        totalCostUsd: 0.01,
+      },
+    });
+
+    const summary = generateGitHubSummary(report, customConfig);
+
+    // Exactly at threshold should be PASS
+    expect(summary).not.toMatch(/Discovery Rate.*FAIL/);
+    expect(summary).not.toMatch(/Avg Adherence.*FAIL/);
+    expect(summary).not.toMatch(/Avg Output Quality.*FAIL/);
   });
 });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -480,13 +480,13 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   const report = await generateJsonResults({ ...reportOptions, outputPath: jsonPath });
 
   if (config.githubSummary) {
-    const wrote = await writeGitHubSummary(report);
+    const wrote = await writeGitHubSummary(report, config);
     if (wrote) {
       console.log('GitHub step summary written');
     }
   }
 
-  const markdownSummary = generateGitHubSummary(report);
+  const markdownSummary = generateGitHubSummary(report, config);
   printSummary(report);
 
   if (comparison) {
@@ -568,7 +568,7 @@ export async function scorePipeline(
   await generateReport({ ...reportOptions, outputPath: reportPath });
   const report = await generateJsonResults({ ...reportOptions, outputPath: jsonPath });
 
-  const markdownSummary = generateGitHubSummary(report);
+  const markdownSummary = generateGitHubSummary(report, config);
   printSummary(report);
 
   return {

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -12,13 +12,15 @@ import type {
   FailureBreakdown,
   CombinedScore,
 } from '../types.js';
+import { loadConfigSync, type EvalConfig } from '../config.js';
 import { FLAKY_STDDEV_THRESHOLD } from '../scorer/aggregator.js';
 import { ARROW_DIRECTION_EPSILON } from './format-utils.js';
 
 /**
  * Generate a condensed summary for GitHub Actions.
  */
-export function generateGitHubSummary(report: EvaluationReport): string {
+export function generateGitHubSummary(report: EvaluationReport, config?: EvalConfig): string {
+  const resolvedConfig = config ?? loadConfigSync();
   const { summary, failureBreakdown, tasks } = report;
   const lines: string[] = [];
 
@@ -28,14 +30,14 @@ export function generateGitHubSummary(report: EvaluationReport): string {
   lines.push('');
 
   // Summary table
-  lines.push('| Metric | Value | Status |');
-  lines.push('|--------|-------|--------|');
-  lines.push(`| Discovery Rate | ${(summary.discoveryAccuracy * 100).toFixed(0)}%${summary.stddev ? ` \u00B1 ${(summary.stddev.discovery * 100).toFixed(0)}%` : ''} (${Math.round(summary.discoveryAccuracy * summary.totalTasks)}/${summary.totalTasks}) | ${summary.discoveryAccuracy >= 0.8 ? 'PASS' : 'FAIL'} |`);
-  lines.push(`| Avg Adherence | ${summary.avgAdherence.toFixed(1)}/5${summary.stddev ? ` \u00B1 ${summary.stddev.adherence.toFixed(1)}` : ''} | ${summary.avgAdherence >= 4.0 ? 'PASS' : 'FAIL'} |`);
-  lines.push(`| Avg Output Quality | ${summary.avgOutputQuality.toFixed(1)}/5${summary.stddev ? ` \u00B1 ${summary.stddev.outputQuality.toFixed(1)}` : ''} | ${summary.avgOutputQuality >= 4.0 ? 'PASS' : 'FAIL'} |`);
-  lines.push(`| Weighted Score | ${summary.avgWeightedScore.toFixed(2)}${summary.stddev ? ` \u00B1 ${summary.stddev.weightedScore.toFixed(2)}` : ''} | |`);
-  lines.push(`| Duration | ${(summary.totalDurationMs / 1000).toFixed(1)}s | |`);
-  lines.push(`| Cost | $${summary.totalCostUsd.toFixed(4)} | |`);
+  lines.push('| Metric | Value | Threshold | Status |');
+  lines.push('|--------|-------|-----------|--------|');
+  lines.push(`| Discovery Rate | ${(summary.discoveryAccuracy * 100).toFixed(0)}%${summary.stddev ? ` \u00B1 ${(summary.stddev.discovery * 100).toFixed(0)}%` : ''} (${Math.round(summary.discoveryAccuracy * summary.totalTasks)}/${summary.totalTasks}) | ${(resolvedConfig.discoveryThreshold * 100).toFixed(0)}% | ${summary.discoveryAccuracy >= resolvedConfig.discoveryThreshold ? 'PASS' : 'FAIL'} |`);
+  lines.push(`| Avg Adherence | ${summary.avgAdherence.toFixed(1)}/5${summary.stddev ? ` \u00B1 ${summary.stddev.adherence.toFixed(1)}` : ''} | ${resolvedConfig.scoreThreshold.toFixed(1)} | ${summary.avgAdherence >= resolvedConfig.scoreThreshold ? 'PASS' : 'FAIL'} |`);
+  lines.push(`| Avg Output Quality | ${summary.avgOutputQuality.toFixed(1)}/5${summary.stddev ? ` \u00B1 ${summary.stddev.outputQuality.toFixed(1)}` : ''} | ${resolvedConfig.scoreThreshold.toFixed(1)} | ${summary.avgOutputQuality >= resolvedConfig.scoreThreshold ? 'PASS' : 'FAIL'} |`);
+  lines.push(`| Weighted Score | ${summary.avgWeightedScore.toFixed(2)}${summary.stddev ? ` \u00B1 ${summary.stddev.weightedScore.toFixed(2)}` : ''} | | |`);
+  lines.push(`| Duration | ${(summary.totalDurationMs / 1000).toFixed(1)}s | | |`);
+  lines.push(`| Cost | $${summary.totalCostUsd.toFixed(4)} | | |`);
   lines.push('');
 
   // Failures
@@ -185,11 +187,11 @@ export function generateGitHubSummary(report: EvaluationReport): string {
 /**
  * Write summary to $GITHUB_STEP_SUMMARY if available.
  */
-export async function writeGitHubSummary(report: EvaluationReport): Promise<boolean> {
+export async function writeGitHubSummary(report: EvaluationReport, config?: EvalConfig): Promise<boolean> {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) return false;
 
-  const summary = generateGitHubSummary(report);
+  const summary = generateGitHubSummary(report, config);
   await fs.appendFile(summaryPath, summary + '\n');
   return true;
 }


### PR DESCRIPTION
## Summary
- Pass `EvalConfig` thresholds to `generateGitHubSummary()` and `writeGitHubSummary()` instead of using hardcoded `0.8` / `4.0` values
- Add a "Threshold" column to the GitHub summary table so users can see what thresholds are applied
- Update `pipeline.ts` callers to thread config through to both functions
- Add tests for custom thresholds, threshold column display, and boundary behavior

Closes #50

## Test plan
- [x] `npm run typecheck` passes
- [x] All 204 tests pass (including 3 new threshold tests)
- [x] Existing tests still pass without config arg (backward-compatible defaults)
- [ ] Verify GitHub Actions summary renders correctly with custom `--threshold-discovery` / `--threshold-score` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)