### PR TITLE
Fix blind comparison fabricated scores for failed tasks

### DIFF
--- a/src/__tests__/blind-comparison.test.ts
+++ b/src/__tests__/blind-comparison.test.ts
@@ -267,6 +267,8 @@ describe('blindCompareAll integration', () => {
     const result = await blindCompareAll(tasks, mockJudge, { randomFn: () => 0.1 });
 
     expect(result.tasks[0].failed).toBe(true);
+    expect(result.tasks[0].outputA).toBeNull();
+    expect(result.tasks[0].outputB).toBeNull();
     expect(result.tasks[0].preferredCondition).toBe('tie');
     expect(result.tasks[0].biasSignal).toBe(false);
     expect(result.aggregate.failedCount).toBe(1);
@@ -355,6 +357,8 @@ describe('blindCompareAll integration', () => {
     expect(result.aggregate.ties).toBe(1); // only successful tie
     expect(result.aggregate.failedCount).toBe(1); // failed task not in ties
     expect(result.tasks[1].failed).toBe(true);
+    expect(result.tasks[1].outputA).toBeNull();
+    expect(result.tasks[1].outputB).toBeNull();
     expect(result.tasks[1].preferredCondition).toBe('tie'); // still tie internally
   });
 });
@@ -477,8 +481,8 @@ describe('generateBlindComparisonSection in markdown report', () => {
         {
           taskId: 'task-2',
           withSkillLabel: 'A',
-          outputA: { instructionFollowing: 1, outputQuality: 1 },
-          outputB: { instructionFollowing: 1, outputQuality: 1 },
+          outputA: null,
+          outputB: null,
           preferred: 'tie',
           reasoning: 'Blind judge call failed',
           preferredCondition: 'tie',

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -486,10 +486,10 @@ Assignment shows the label order: with-skill / without-skill (e.g. A/B means A =
 
   for (const t of blind.tasks) {
     const labels = t.withSkillLabel === 'A' ? 'A/B' : 'B/A';
-    const aInstr = t.failed ? 'N/A' : `${t.outputA.instructionFollowing}/5`;
-    const aOut = t.failed ? 'N/A' : `${t.outputA.outputQuality}/5`;
-    const bInstr = t.failed ? 'N/A' : `${t.outputB.instructionFollowing}/5`;
-    const bOut = t.failed ? 'N/A' : `${t.outputB.outputQuality}/5`;
+    const aInstr = t.failed || !t.outputA ? 'N/A' : `${t.outputA.instructionFollowing}/5`;
+    const aOut = t.failed || !t.outputA ? 'N/A' : `${t.outputA.outputQuality}/5`;
+    const bInstr = t.failed || !t.outputB ? 'N/A' : `${t.outputB.instructionFollowing}/5`;
+    const bOut = t.failed || !t.outputB ? 'N/A' : `${t.outputB.outputQuality}/5`;
     section += `| ${t.taskId} | ${labels} | ${aInstr} | ${aOut} | ${bInstr} | ${bOut} | ${t.preferred} | ${t.preferredCondition} | ${t.biasSignal ? 'Yes' : 'No'} |\n`;
   }
 

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -595,8 +595,8 @@ export async function blindCompareAll(
       return {
         taskId: task.taskId,
         withSkillLabel,
-        outputA: { instructionFollowing: 1, outputQuality: 1 },
-        outputB: { instructionFollowing: 1, outputQuality: 1 },
+        outputA: null,
+        outputB: null,
         preferred: 'tie',
         reasoning: 'Blind judge call failed',
         preferredCondition: 'tie',

--- a/src/types.ts
+++ b/src/types.ts
@@ -356,8 +356,8 @@ export interface BlindOutputScore {
 export interface BlindTaskComparison {
   taskId: string;
   withSkillLabel: 'A' | 'B';           // which label the with-skill output got
-  outputA: BlindOutputScore;
-  outputB: BlindOutputScore;
+  outputA: BlindOutputScore | null;
+  outputB: BlindOutputScore | null;
   preferred: 'A' | 'B' | 'tie';
   reasoning: string;
   preferredCondition: 'with-skill' | 'without-skill' | 'tie';


### PR DESCRIPTION
## Summary

- Make `outputA`/`outputB` nullable (`BlindOutputScore | null`) in `BlindTaskComparison` type
- Store `null` instead of fabricated `{ instructionFollowing: 1, outputQuality: 1 }` when a blind judge call fails
- Add null guards in markdown report rendering for TypeScript safety
- Add `toBeNull()` assertions in blind comparison tests

Closes #74

## Test plan

- [x] `npm run typecheck` passes with no errors
- [x] All 201 tests pass (`npm test`), including 23 blind-comparison tests
- [ ] Verify JSON output shows `"outputA": null, "outputB": null` for failed blind tasks (manual run with `--compare --blind-compare`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)