### PR TITLE
Fix scale-dependent qualityImpact threshold

### DIFF
--- a/src/__tests__/report-impact.test.ts
+++ b/src/__tests__/report-impact.test.ts
@@ -36,6 +36,10 @@ describe('qualityImpact', () => {
     expect(qualityImpact(-DISCOVERY_IMPACT_THRESHOLD, DISCOVERY_IMPACT_THRESHOLD)).toBe('Neutral');
     expect(qualityImpact(ADHERENCE_IMPACT_THRESHOLD, ADHERENCE_IMPACT_THRESHOLD)).toBe('Neutral');
     expect(qualityImpact(-ADHERENCE_IMPACT_THRESHOLD, ADHERENCE_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(OUTPUT_QUALITY_IMPACT_THRESHOLD, OUTPUT_QUALITY_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(-OUTPUT_QUALITY_IMPACT_THRESHOLD, OUTPUT_QUALITY_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(WEIGHTED_SCORE_IMPACT_THRESHOLD, WEIGHTED_SCORE_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(-WEIGHTED_SCORE_IMPACT_THRESHOLD, WEIGHTED_SCORE_IMPACT_THRESHOLD)).toBe('Neutral');
   });
 });
 

--- a/src/__tests__/report-impact.test.ts
+++ b/src/__tests__/report-impact.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  qualityImpact,
+  DISCOVERY_IMPACT_THRESHOLD,
+  ADHERENCE_IMPACT_THRESHOLD,
+  OUTPUT_QUALITY_IMPACT_THRESHOLD,
+  WEIGHTED_SCORE_IMPACT_THRESHOLD,
+} from '../report/report.js';
+
+describe('qualityImpact', () => {
+  it('classifies positive delta above threshold', () => {
+    expect(qualityImpact(0.06, DISCOVERY_IMPACT_THRESHOLD)).toBe('Positive');
+    expect(qualityImpact(0.25, ADHERENCE_IMPACT_THRESHOLD)).toBe('Positive');
+    expect(qualityImpact(0.25, OUTPUT_QUALITY_IMPACT_THRESHOLD)).toBe('Positive');
+    expect(qualityImpact(0.06, WEIGHTED_SCORE_IMPACT_THRESHOLD)).toBe('Positive');
+  });
+
+  it('classifies negative delta below threshold', () => {
+    expect(qualityImpact(-0.06, DISCOVERY_IMPACT_THRESHOLD)).toBe('Negative');
+    expect(qualityImpact(-0.25, ADHERENCE_IMPACT_THRESHOLD)).toBe('Negative');
+    expect(qualityImpact(-0.25, OUTPUT_QUALITY_IMPACT_THRESHOLD)).toBe('Negative');
+    expect(qualityImpact(-0.06, WEIGHTED_SCORE_IMPACT_THRESHOLD)).toBe('Negative');
+  });
+
+  it('classifies delta within threshold as Neutral', () => {
+    expect(qualityImpact(0.04, DISCOVERY_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(-0.04, DISCOVERY_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(0.15, ADHERENCE_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(-0.15, OUTPUT_QUALITY_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(0.03, WEIGHTED_SCORE_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(0, DISCOVERY_IMPACT_THRESHOLD)).toBe('Neutral');
+  });
+
+  it('classifies exact threshold value as Neutral (not strictly greater)', () => {
+    expect(qualityImpact(DISCOVERY_IMPACT_THRESHOLD, DISCOVERY_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(-DISCOVERY_IMPACT_THRESHOLD, DISCOVERY_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(ADHERENCE_IMPACT_THRESHOLD, ADHERENCE_IMPACT_THRESHOLD)).toBe('Neutral');
+    expect(qualityImpact(-ADHERENCE_IMPACT_THRESHOLD, ADHERENCE_IMPACT_THRESHOLD)).toBe('Neutral');
+  });
+});
+
+describe('impact threshold values', () => {
+  it('are calibrated to ~5% of each scale range', () => {
+    expect(DISCOVERY_IMPACT_THRESHOLD).toBe(0.05);       // 5% of 0-1 range
+    expect(ADHERENCE_IMPACT_THRESHOLD).toBe(0.20);       // 5% of 1-5 range (range = 4)
+    expect(OUTPUT_QUALITY_IMPACT_THRESHOLD).toBe(0.20);  // 5% of 1-5 range (range = 4)
+    expect(WEIGHTED_SCORE_IMPACT_THRESHOLD).toBe(0.05);  // 5% of 0-1 range
+  });
+});

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -440,7 +440,7 @@ const DURATION_IMPACT_THRESHOLD_MS = 1000;
 /** Minimum cost delta (USD) to classify as higher/lower. */
 const COST_IMPACT_THRESHOLD_USD = 0.0001;
 
-export function qualityImpact(delta: number, threshold: number): string {
+export function qualityImpact(delta: number, threshold: number): 'Positive' | 'Negative' | 'Neutral' {
   if (delta > threshold) return 'Positive';
   if (delta < -threshold) return 'Negative';
   return 'Neutral';

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -408,9 +408,9 @@ function generateComparisonSection(comparison: ComparisonData): string {
 
 | Metric | With Skill | Baseline | Delta | Impact |
 |--------|-----------|----------|-------|--------|
-| Discovery | ${(ws.discoveryAccuracy * 100).toFixed(0)}% | ${(bs.discoveryAccuracy * 100).toFixed(0)}% | ${formatDelta(d.discoveryAccuracyDelta * 100, 0)}% | ${qualityImpact(d.discoveryAccuracyDelta)} |
-| Avg Adherence | ${ws.avgAdherence.toFixed(2)}/5 | ${bs.avgAdherence.toFixed(2)}/5 | ${formatDelta(d.avgAdherenceDelta)} | ${qualityImpact(d.avgAdherenceDelta)} |
-| Avg Output Quality | ${ws.avgOutputQuality.toFixed(2)}/5 | ${bs.avgOutputQuality.toFixed(2)}/5 | ${formatDelta(d.avgOutputQualityDelta)} | ${qualityImpact(d.avgOutputQualityDelta)} |
+| Discovery | ${(ws.discoveryAccuracy * 100).toFixed(0)}% | ${(bs.discoveryAccuracy * 100).toFixed(0)}% | ${formatDelta(d.discoveryAccuracyDelta * 100, 0)}% | ${qualityImpact(d.discoveryAccuracyDelta, DISCOVERY_IMPACT_THRESHOLD)} |
+| Avg Adherence | ${ws.avgAdherence.toFixed(2)}/5 | ${bs.avgAdherence.toFixed(2)}/5 | ${formatDelta(d.avgAdherenceDelta)} | ${qualityImpact(d.avgAdherenceDelta, ADHERENCE_IMPACT_THRESHOLD)} |
+| Avg Output Quality | ${ws.avgOutputQuality.toFixed(2)}/5 | ${bs.avgOutputQuality.toFixed(2)}/5 | ${formatDelta(d.avgOutputQualityDelta)} | ${qualityImpact(d.avgOutputQualityDelta, OUTPUT_QUALITY_IMPACT_THRESHOLD)} |
 | Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | ${formatDelta(d.avgWeightedScoreDelta)} | ${qualityImpact(d.avgWeightedScoreDelta, WEIGHTED_SCORE_IMPACT_THRESHOLD)} |
 | Duration | ${(ws.totalDurationMs / 1000).toFixed(1)}s | ${(bs.totalDurationMs / 1000).toFixed(1)}s | ${formatDelta(d.totalDurationDeltaMs / 1000, 1)}s | ${durationImpact(d.totalDurationDeltaMs)} |
 | Cost | $${ws.totalCostUsd.toFixed(4)} | $${bs.totalCostUsd.toFixed(4)} | $${formatDelta(d.totalCostDeltaUsd, 4)} | ${costImpact(d.totalCostDeltaUsd)} |
@@ -430,16 +430,17 @@ function generateComparisonSection(comparison: ComparisonData): string {
   return section;
 }
 
-/** Minimum score delta to classify as positive/negative impact (on 1-5 scale, ~2.5% of range). */
-const QUALITY_IMPACT_THRESHOLD = 0.1;
-/** Minimum weighted score delta (on 0-1 scale, ~2% of range). */
-const WEIGHTED_SCORE_IMPACT_THRESHOLD = 0.02;
+/** Minimum delta to classify as positive/negative impact, calibrated to ~5% of each metric's range. */
+export const DISCOVERY_IMPACT_THRESHOLD = 0.05;       // 5% of 0-1 range
+export const ADHERENCE_IMPACT_THRESHOLD = 0.20;       // 5% of 1-5 range (range = 4)
+export const OUTPUT_QUALITY_IMPACT_THRESHOLD = 0.20;  // 5% of 1-5 range (range = 4)
+export const WEIGHTED_SCORE_IMPACT_THRESHOLD = 0.05;  // 5% of 0-1 range
 /** Minimum duration delta (ms) to classify as slower/faster. */
 const DURATION_IMPACT_THRESHOLD_MS = 1000;
 /** Minimum cost delta (USD) to classify as higher/lower. */
 const COST_IMPACT_THRESHOLD_USD = 0.0001;
 
-function qualityImpact(delta: number, threshold = QUALITY_IMPACT_THRESHOLD): string {
+export function qualityImpact(delta: number, threshold: number): string {
   if (delta > threshold) return 'Positive';
   if (delta < -threshold) return 'Negative';
   return 'Neutral';


### PR DESCRIPTION
## Summary

Closes #52

- Replaced the single `QUALITY_IMPACT_THRESHOLD = 0.1` with four per-metric constants, each calibrated to **5% of the metric's range**, so impact classification ("Positive"/"Negative"/"Neutral") is consistent across all scales
- Removed the default parameter from `qualityImpact()` so every call site must explicitly choose its threshold, preventing future drift
- Added unit tests for the impact classification function and threshold values

| Metric | Scale | Old Threshold | % of Range | New Threshold | % of Range |
|--------|-------|---------------|------------|---------------|------------|
| Discovery | 0-1 | 0.1 | 10% | 0.05 | 5% |
| Adherence | 1-5 | 0.1 | 2.5% | 0.20 | 5% |
| Output Quality | 1-5 | 0.1 | 2.5% | 0.20 | 5% |
| Weighted Score | 0-1 | 0.02 | 2% | 0.05 | 5% |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — all 206 tests pass (including 5 new impact tests)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)