### PR TITLE
Add bounded concurrency for parallel task execution

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Per-task timeout in milliseconds'
     required: false
     default: '300000'
+  concurrency:
+    description: 'Max concurrent tasks (1=sequential, 0=unlimited)'
+    required: false
+    default: '1'
   tasks-filter:
     description: 'Comma-separated list of task IDs to run'
     required: false

--- a/action/dist/index.cjs
+++ b/action/dist/index.cjs
@@ -22591,9 +22591,14 @@ function loadEnvConfig() {
   const timeout = parseInt(process.env.EVAL_TASK_TIMEOUT_MS || "", 10);
   if (!isNaN(timeout))
     config2.taskTimeoutMs = timeout;
-  const concurrency = parseInt(process.env.EVAL_RUNNER_CONCURRENCY || "", 10);
-  if (!isNaN(concurrency) && concurrency >= 0)
+  const concurrencyRaw = process.env.EVAL_RUNNER_CONCURRENCY;
+  if (concurrencyRaw !== void 0 && concurrencyRaw !== "") {
+    const concurrency = Number(concurrencyRaw);
+    if (!Number.isInteger(concurrency) || concurrency < 0) {
+      throw new Error(`Invalid EVAL_RUNNER_CONCURRENCY "${concurrencyRaw}". Must be a non-negative integer.`);
+    }
     config2.concurrency = concurrency;
+  }
   if (process.env.EVAL_EXIT_ON_FAILURE !== void 0) {
     config2.exitOnFailure = process.env.EVAL_EXIT_ON_FAILURE !== "false";
   }
@@ -22719,7 +22724,6 @@ var init_base_runner = __esm({
         const resolvedConfig = config2 ?? loadConfigSync();
         this.options = {
           cwd: options.cwd ?? process.cwd(),
-          parallel: options.parallel ?? false,
           // Precedence: explicit concurrency > parallel (deprecated, maps to unlimited) > config file > default (1)
           concurrency: options.concurrency ?? (options.parallel ? 0 : void 0) ?? resolvedConfig.concurrency ?? DEFAULT_RUNNER_CONCURRENCY,
           model: options.model ?? resolvedConfig.defaultAgentModel,
@@ -47866,9 +47870,10 @@ async function run() {
     const thresholdDiscovery = parseFloat(core2.getInput("threshold-discovery") || "0.8");
     const thresholdScore = parseFloat(core2.getInput("threshold-score") || "4.0");
     const timeout = parseInt(core2.getInput("timeout") || "300000", 10);
-    const concurrency = parseInt(core2.getInput("concurrency") || "1", 10);
-    if (isNaN(concurrency) || concurrency < 0) {
-      core2.setFailed("concurrency input must be an integer >= 0");
+    const concurrencyRaw = core2.getInput("concurrency") || "1";
+    const concurrency = Number(concurrencyRaw);
+    if (!Number.isInteger(concurrency) || concurrency < 0) {
+      core2.setFailed("concurrency input must be a non-negative integer");
       return;
     }
     const tasksFilter = core2.getInput("tasks-filter") || void 0;

--- a/action/dist/index.cjs
+++ b/action/dist/index.cjs
@@ -22444,28 +22444,29 @@ var init_js_yaml = __esm({
 });
 
 // dist/src/runner/security.js
+function resolveWriteDirs(allowedWriteDirs, cwd2) {
+  return allowedWriteDirs.map((dir) => {
+    const resolved = path2.resolve(cwd2, dir);
+    return resolved.endsWith(path2.sep) ? resolved : resolved + path2.sep;
+  });
+}
+function isPathInDirs(resolvedPath, resolvedDirs) {
+  return resolvedDirs.some((dir) => resolvedPath.startsWith(dir) || resolvedPath === dir.slice(0, -1));
+}
 function isWriteAllowed(resolvedPath, allowedWriteDirs, cwd2) {
   if (allowedWriteDirs.length === 0)
     return true;
-  const resolvedDirs = allowedWriteDirs.map((dir) => {
-    const resolved = path2.resolve(cwd2, dir);
-    return resolved.endsWith(path2.sep) ? resolved : resolved + path2.sep;
-  });
-  return resolvedDirs.some((dir) => resolvedPath.startsWith(dir) || resolvedPath === dir.slice(0, -1));
+  return isPathInDirs(resolvedPath, resolveWriteDirs(allowedWriteDirs, cwd2));
 }
 function createToolPolicy(allowedWriteDirs, cwd2) {
-  const resolvedDirs = allowedWriteDirs.map((dir) => {
-    const resolved = path2.resolve(cwd2, dir);
-    return resolved.endsWith(path2.sep) ? resolved : resolved + path2.sep;
-  });
+  const resolvedDirs = resolveWriteDirs(allowedWriteDirs, cwd2);
   return async (toolName, input, _options) => {
     if (!["Write", "Edit"].includes(toolName)) {
       return { behavior: "allow", updatedInput: input };
     }
     const filePath = input.file_path || "";
     const resolvedPath = path2.resolve(cwd2, filePath);
-    const isAllowed = resolvedDirs.some((dir) => resolvedPath.startsWith(dir) || resolvedPath === dir.slice(0, -1));
-    if (isAllowed) {
+    if (isPathInDirs(resolvedPath, resolvedDirs)) {
       return { behavior: "allow", updatedInput: input };
     }
     return {
@@ -22479,6 +22480,35 @@ var init_security = __esm({
   "dist/src/runner/security.js"() {
     "use strict";
     path2 = __toESM(require("path"), 1);
+  }
+});
+
+// dist/src/utils/concurrency.js
+async function withConcurrencyLimit(factories, limit = DEFAULT_CONCURRENCY) {
+  if (factories.length === 0)
+    return [];
+  if (limit < 0) {
+    throw new RangeError(`Concurrency limit must be >= 0, got ${limit}`);
+  }
+  const effectiveLimit = limit === 0 ? factories.length : limit;
+  const results = new Array(factories.length);
+  let next = 0;
+  async function worker() {
+    while (next < factories.length) {
+      const idx = next++;
+      results[idx] = await factories[idx]();
+    }
+  }
+  const workers = Array.from({ length: Math.min(effectiveLimit, factories.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+var DEFAULT_CONCURRENCY, DEFAULT_RUNNER_CONCURRENCY;
+var init_concurrency = __esm({
+  "dist/src/utils/concurrency.js"() {
+    "use strict";
+    DEFAULT_CONCURRENCY = 5;
+    DEFAULT_RUNNER_CONCURRENCY = 1;
   }
 });
 
@@ -22514,6 +22544,12 @@ async function loadConfigFile(configPath) {
       config2.scoreThreshold = raw.thresholds.avg_score;
     if (raw.runner?.timeout_ms !== void 0)
       config2.taskTimeoutMs = raw.runner.timeout_ms;
+    if (raw.runner?.concurrency !== void 0) {
+      if (!Number.isInteger(raw.runner.concurrency) || raw.runner.concurrency < 0) {
+        throw new Error(`Invalid runner.concurrency "${raw.runner.concurrency}" in config file. Must be a non-negative integer.`);
+      }
+      config2.concurrency = raw.runner.concurrency;
+    }
     if (raw.runner?.allowed_write_dirs)
       config2.allowedWriteDirs = raw.runner.allowed_write_dirs;
     if (raw.output?.dir)
@@ -22555,6 +22591,9 @@ function loadEnvConfig() {
   const timeout = parseInt(process.env.EVAL_TASK_TIMEOUT_MS || "", 10);
   if (!isNaN(timeout))
     config2.taskTimeoutMs = timeout;
+  const concurrency = parseInt(process.env.EVAL_RUNNER_CONCURRENCY || "", 10);
+  if (!isNaN(concurrency) && concurrency >= 0)
+    config2.concurrency = concurrency;
   if (process.env.EVAL_EXIT_ON_FAILURE !== void 0) {
     config2.exitOnFailure = process.env.EVAL_EXIT_ON_FAILURE !== "false";
   }
@@ -22588,6 +22627,8 @@ function mergeConfigs(...configs) {
       result.reportOutputTruncation = config2.reportOutputTruncation;
     if (config2.taskTimeoutMs !== void 0)
       result.taskTimeoutMs = config2.taskTimeoutMs;
+    if (config2.concurrency !== void 0)
+      result.concurrency = config2.concurrency;
     if (config2.exitOnFailure !== void 0)
       result.exitOnFailure = config2.exitOnFailure;
     if (config2.outputDir !== void 0)
@@ -22627,6 +22668,7 @@ var init_config = __esm({
     init_js_yaml();
     fs4 = __toESM(require("fs/promises"), 1);
     path3 = __toESM(require("path"), 1);
+    init_concurrency();
     VALID_RUNNER_TYPES = ["claude-sdk", "vercel-ai", "openai-agents", "copilot-sdk"];
     DEFAULT_CONFIG = {
       runnerType: "claude-sdk",
@@ -22641,6 +22683,8 @@ var init_config = __esm({
       reportOutputTruncation: 2e3,
       taskTimeoutMs: 3e5,
       // 5 minutes
+      concurrency: DEFAULT_RUNNER_CONCURRENCY,
+      // sequential by default
       exitOnFailure: true,
       outputDir: "./results",
       githubSummary: false,
@@ -22657,6 +22701,7 @@ var init_base_runner = __esm({
   "dist/src/runner/base-runner.js"() {
     "use strict";
     init_config();
+    init_concurrency();
     BaseRunner = class {
       options;
       /** Read-only access to resolved runner options (for testing and introspection). */
@@ -22675,6 +22720,8 @@ var init_base_runner = __esm({
         this.options = {
           cwd: options.cwd ?? process.cwd(),
           parallel: options.parallel ?? false,
+          // Precedence: explicit concurrency > parallel (deprecated, maps to unlimited) > config file > default (1)
+          concurrency: options.concurrency ?? (options.parallel ? 0 : void 0) ?? resolvedConfig.concurrency ?? DEFAULT_RUNNER_CONCURRENCY,
           model: options.model ?? resolvedConfig.defaultAgentModel,
           taskTimeoutMs: options.taskTimeoutMs ?? resolvedConfig.taskTimeoutMs,
           allowedWriteDirs: options.allowedWriteDirs ?? resolvedConfig.allowedWriteDirs,
@@ -22698,6 +22745,18 @@ var init_base_runner = __esm({
           isError: true,
           errorMessage
         };
+      }
+      /**
+       * Dynamically import a module, throwing a helpful error if missing.
+       * Protected to allow test subclasses to inject mocks.
+       */
+      async dynamicImport(pkg, installHint) {
+        try {
+          return await Function("pkg", "return import(pkg)")(pkg);
+        } catch (err) {
+          const detail = err instanceof Error ? `: ${err.message}` : "";
+          throw new Error(`${pkg} is required${detail}. Install with: npm install ${installHint}`);
+        }
       }
       /**
        * Execute a task with timeout protection.
@@ -22724,37 +22783,33 @@ var init_base_runner = __esm({
       }
       /**
        * Run all tasks in an evaluation suite.
+       *
+       * Concurrency is controlled by `options.concurrency`:
+       * - 1 = sequential (default)
+       * - 0 = unlimited
+       * - N = at most N tasks in flight
        */
       async runAll(evaluation, createLogger) {
-        if (this.options.parallel) {
-          const results2 = await Promise.allSettled(evaluation.tasks.map((task) => {
+        const limit = this.options.concurrency ?? 1;
+        const factories = evaluation.tasks.map((task) => async () => {
+          console.log(`Running task ${task.id}: ${task.prompt.length > 60 ? task.prompt.slice(0, 60) + "..." : task.prompt}`);
+          try {
             const logger = createLogger?.(task);
-            return this.runTaskWithTimeout(task, void 0, logger);
-          }));
-          return results2.map((result, i) => {
-            if (result.status === "fulfilled") {
-              return result.value;
+            const result = await this.runTaskWithTimeout(task, void 0, logger);
+            if (result.isError) {
+              console.error(`  Task ${task.id} ERROR: ${result.errorMessage}`);
+            } else {
+              console.log(`  Task ${task.id} done \u2014 Skills loaded: ${result.skillLoads.join(", ") || "none"}`);
+              console.log(`  Duration: ${(result.durationMs / 1e3).toFixed(1)}s | Cost: $${result.costUsd.toFixed(4)}`);
             }
-            const task = evaluation.tasks[i];
-            const errMsg = result.reason?.message || "Unknown error";
+            return result;
+          } catch (error2) {
+            const errMsg = error2 instanceof Error ? error2.message : String(error2);
             console.error(`  Task ${task.id} ERROR: ${errMsg}`);
             return this.createErrorResult(task, errMsg, 0);
-          });
-        }
-        const results = [];
-        for (const task of evaluation.tasks) {
-          console.log(`Running task ${task.id}: ${task.prompt.length > 60 ? task.prompt.slice(0, 60) + "..." : task.prompt}`);
-          const logger = createLogger?.(task);
-          const result = await this.runTaskWithTimeout(task, void 0, logger);
-          results.push(result);
-          if (result.isError) {
-            console.error(`  ERROR: ${result.errorMessage}`);
-          } else {
-            console.log(`  Skills loaded: ${result.skillLoads.join(", ") || "none"}`);
-            console.log(`  Duration: ${(result.durationMs / 1e3).toFixed(1)}s | Cost: $${result.costUsd.toFixed(4)}`);
           }
-        }
-        return results;
+        });
+        return withConcurrencyLimit(factories, limit);
       }
     };
   }
@@ -22886,18 +22941,6 @@ var init_vercel_ai_runner = __esm({
     execAsync = (0, import_util.promisify)(import_child_process2.exec);
     VercelAiRunner = class extends BaseRunner {
       providerName = "vercel-ai";
-      /**
-       * Dynamically import a module, throwing a helpful error if missing.
-       * Protected to allow test subclasses to inject mocks.
-       */
-      async dynamicImport(pkg, installHint) {
-        try {
-          return await Function("pkg", "return import(pkg)")(pkg);
-        } catch (err) {
-          const detail = err instanceof Error ? `: ${err.message}` : "";
-          throw new Error(`${pkg} is required${detail}. Install with: npm install ${installHint}`);
-        }
-      }
       async runTask(task, logger) {
         const importFn = this.dynamicImport.bind(this);
         const { generateText, tool: defineTool, stepCountIs } = await importFn("ai", "ai");
@@ -23282,18 +23325,6 @@ var init_copilot_sdk_runner = __esm({
         return !!(this.sdkOptions.githubToken ?? process.env.COPILOT_GITHUB_TOKEN);
       }
       /**
-       * Dynamically import a module, throwing a helpful error if missing.
-       * Protected to allow test subclasses to inject mocks.
-       */
-      async dynamicImport(pkg, installHint) {
-        try {
-          return await Function("pkg", "return import(pkg)")(pkg);
-        } catch (err) {
-          const detail = err instanceof Error ? `: ${err.message}` : "";
-          throw new Error(`${pkg} is required${detail}. Install with: npm install ${installHint}`);
-        }
-      }
-      /**
        * Get or create a lazy CopilotClient singleton.
        * Reused across tasks to avoid per-task server startup overhead.
        */
@@ -23504,6 +23535,7 @@ var path10 = __toESM(require("path"), 1);
 var fs13 = __toESM(require("fs/promises"), 1);
 
 // dist/src/utils/format.js
+var ARROW_DIRECTION_EPSILON = 1e-3;
 function formatDelta(value, decimals = 2) {
   if (value === 0)
     return decimals > 0 ? `0.${"0".repeat(decimals)}` : "0";
@@ -45763,6 +45795,7 @@ function getFeedbackForTask(feedback, taskId) {
 
 // dist/src/scorer/judge.js
 init_config();
+init_concurrency();
 var JUDGE_PROMPT_TEMPLATE = `You are an expert evaluator for AI agent skills. Score this skill evaluation result.
 
 ## Task Information
@@ -46298,20 +46331,6 @@ async function blindCompareAll(tasks, judge, options) {
   };
   return { tasks: blindTasks, aggregate };
 }
-var DEFAULT_CONCURRENCY = 5;
-async function withConcurrencyLimit(factories, limit = DEFAULT_CONCURRENCY) {
-  const results = new Array(factories.length);
-  let next = 0;
-  async function worker() {
-    while (next < factories.length) {
-      const idx = next++;
-      results[idx] = await factories[idx]();
-    }
-  }
-  const workers = Array.from({ length: Math.min(limit, factories.length) }, () => worker());
-  await Promise.all(workers);
-  return results;
-}
 function capitalize(s) {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
@@ -46694,15 +46713,6 @@ function aggregateScores(allScores) {
 
 // dist/src/report/comparison.js
 var fs10 = __toESM(require("fs/promises"), 1);
-
-// dist/src/report/format-utils.js
-var ARROW_DIRECTION_EPSILON = 1e-3;
-function formatDelta2(value, suffix = "") {
-  const sign = value > 0 ? "+" : "";
-  return `${sign}${value.toFixed(2)}${suffix}`;
-}
-
-// dist/src/report/comparison.js
 var SIGNIFICANCE_THRESHOLD_ADHERENCE = 1;
 var SIGNIFICANCE_THRESHOLD_WEIGHTED = 0.15;
 async function loadPreviousReport(filePath) {
@@ -46844,10 +46854,10 @@ function formatComparisonMarkdown(comparison) {
   lines.push("");
   lines.push("| Metric | Previous | Current | Delta | |");
   lines.push("|--------|----------|---------|-------|-|");
-  lines.push(summaryRow("Discovery Accuracy", `${(d.previous.discoveryAccuracy * 100).toFixed(1)}%`, `${(d.current.discoveryAccuracy * 100).toFixed(1)}%`, formatDelta2(d.delta.discoveryAccuracy * 100, "%"), d.delta.discoveryAccuracy));
-  lines.push(summaryRow("Avg Adherence", `${d.previous.avgAdherence.toFixed(2)}/5`, `${d.current.avgAdherence.toFixed(2)}/5`, formatDelta2(d.delta.avgAdherence), d.delta.avgAdherence));
-  lines.push(summaryRow("Avg Output Quality", `${d.previous.avgOutputQuality.toFixed(2)}/5`, `${d.current.avgOutputQuality.toFixed(2)}/5`, formatDelta2(d.delta.avgOutputQuality), d.delta.avgOutputQuality));
-  lines.push(summaryRow("Weighted Score", d.previous.avgWeightedScore.toFixed(2), d.current.avgWeightedScore.toFixed(2), formatDelta2(d.delta.avgWeightedScore), d.delta.avgWeightedScore));
+  lines.push(summaryRow("Discovery Accuracy", `${(d.previous.discoveryAccuracy * 100).toFixed(1)}%`, `${(d.current.discoveryAccuracy * 100).toFixed(1)}%`, formatDelta(d.delta.discoveryAccuracy * 100) + "%", d.delta.discoveryAccuracy));
+  lines.push(summaryRow("Avg Adherence", `${d.previous.avgAdherence.toFixed(2)}/5`, `${d.current.avgAdherence.toFixed(2)}/5`, formatDelta(d.delta.avgAdherence), d.delta.avgAdherence));
+  lines.push(summaryRow("Avg Output Quality", `${d.previous.avgOutputQuality.toFixed(2)}/5`, `${d.current.avgOutputQuality.toFixed(2)}/5`, formatDelta(d.delta.avgOutputQuality), d.delta.avgOutputQuality));
+  lines.push(summaryRow("Weighted Score", d.previous.avgWeightedScore.toFixed(2), d.current.avgWeightedScore.toFixed(2), formatDelta(d.delta.avgWeightedScore), d.delta.avgWeightedScore));
   lines.push("");
   if (comparison.taskDeltas.length > 0) {
     lines.push("### Per-Task Changes");
@@ -46880,10 +46890,10 @@ function formatComparisonConsole(comparison) {
   lines.push("-".repeat(50));
   lines.push("  Comparison vs. Previous");
   lines.push("-".repeat(50));
-  lines.push(`  Discovery:    ${formatDelta2(d.discoveryAccuracy * 100)}%`);
-  lines.push(`  Adherence:    ${formatDelta2(d.avgAdherence)}`);
-  lines.push(`  Output:       ${formatDelta2(d.avgOutputQuality)}`);
-  lines.push(`  Weighted:     ${formatDelta2(d.avgWeightedScore)}`);
+  lines.push(`  Discovery:    ${formatDelta(d.discoveryAccuracy * 100)}%`);
+  lines.push(`  Adherence:    ${formatDelta(d.avgAdherence)}`);
+  lines.push(`  Output:       ${formatDelta(d.avgOutputQuality)}`);
+  lines.push(`  Weighted:     ${formatDelta(d.avgWeightedScore)}`);
   const improved = comparison.taskDeltas.filter((t) => t.significantChange === "improved");
   const regressed = comparison.taskDeltas.filter((t) => t.significantChange === "regressed");
   if (improved.length > 0) {
@@ -47488,7 +47498,7 @@ async function runPhase(phaseLabel, evaluation, config2, cwd2, skillsDir, numRun
   const runner = await createRunner(config2.runnerType, {
     cwd: cwd2,
     model: config2.defaultAgentModel,
-    parallel: false,
+    concurrency: config2.concurrency,
     allowedWriteDirs: config2.allowedWriteDirs,
     skillsDir
   }, config2);
@@ -47856,6 +47866,11 @@ async function run() {
     const thresholdDiscovery = parseFloat(core2.getInput("threshold-discovery") || "0.8");
     const thresholdScore = parseFloat(core2.getInput("threshold-score") || "4.0");
     const timeout = parseInt(core2.getInput("timeout") || "300000", 10);
+    const concurrency = parseInt(core2.getInput("concurrency") || "1", 10);
+    if (isNaN(concurrency) || concurrency < 0) {
+      core2.setFailed("concurrency input must be an integer >= 0");
+      return;
+    }
     const tasksFilter = core2.getInput("tasks-filter") || void 0;
     const skillsDir = core2.getInput("skills-dir") || void 0;
     const cwd2 = core2.getInput("working-directory") || process.cwd();
@@ -47900,6 +47915,7 @@ async function run() {
       discoveryThreshold: thresholdDiscovery,
       scoreThreshold: thresholdScore,
       taskTimeoutMs: timeout,
+      concurrency,
       githubSummary: true
     };
     const result = await runPipeline({

--- a/action/index.ts
+++ b/action/index.ts
@@ -27,6 +27,10 @@ async function run(): Promise<void> {
     const thresholdScore = parseFloat(core.getInput('threshold-score') || '4.0');
     const timeout = parseInt(core.getInput('timeout') || '300000', 10);
     const concurrency = parseInt(core.getInput('concurrency') || '1', 10);
+    if (isNaN(concurrency) || concurrency < 0) {
+      core.setFailed('concurrency input must be an integer >= 0');
+      return;
+    }
     const tasksFilter = core.getInput('tasks-filter') || undefined;
     const skillsDir = core.getInput('skills-dir') || undefined;
     const cwd = core.getInput('working-directory') || process.cwd();

--- a/action/index.ts
+++ b/action/index.ts
@@ -26,9 +26,10 @@ async function run(): Promise<void> {
     const thresholdDiscovery = parseFloat(core.getInput('threshold-discovery') || '0.8');
     const thresholdScore = parseFloat(core.getInput('threshold-score') || '4.0');
     const timeout = parseInt(core.getInput('timeout') || '300000', 10);
-    const concurrency = parseInt(core.getInput('concurrency') || '1', 10);
-    if (isNaN(concurrency) || concurrency < 0) {
-      core.setFailed('concurrency input must be an integer >= 0');
+    const concurrencyRaw = core.getInput('concurrency') || '1';
+    const concurrency = Number(concurrencyRaw);
+    if (!Number.isInteger(concurrency) || concurrency < 0) {
+      core.setFailed('concurrency input must be a non-negative integer');
       return;
     }
     const tasksFilter = core.getInput('tasks-filter') || undefined;

--- a/action/index.ts
+++ b/action/index.ts
@@ -26,6 +26,7 @@ async function run(): Promise<void> {
     const thresholdDiscovery = parseFloat(core.getInput('threshold-discovery') || '0.8');
     const thresholdScore = parseFloat(core.getInput('threshold-score') || '4.0');
     const timeout = parseInt(core.getInput('timeout') || '300000', 10);
+    const concurrency = parseInt(core.getInput('concurrency') || '1', 10);
     const tasksFilter = core.getInput('tasks-filter') || undefined;
     const skillsDir = core.getInput('skills-dir') || undefined;
     const cwd = core.getInput('working-directory') || process.cwd();
@@ -80,6 +81,7 @@ async function run(): Promise<void> {
       discoveryThreshold: thresholdDiscovery,
       scoreThreshold: thresholdScore,
       taskTimeoutMs: timeout,
+      concurrency,
       githubSummary: true,
     };
 

--- a/src/__tests__/concurrency.test.ts
+++ b/src/__tests__/concurrency.test.ts
@@ -83,6 +83,12 @@ describe('withConcurrencyLimit', () => {
     const results = await withConcurrencyLimit(factories, 100);
     expect(results).toEqual([1, 2]);
   });
+
+  it('throws RangeError for negative limit', async () => {
+    const factories = [async () => 1];
+    await expect(withConcurrencyLimit(factories, -1)).rejects.toThrow(RangeError);
+    await expect(withConcurrencyLimit(factories, -5)).rejects.toThrow('Concurrency limit must be >= 0');
+  });
 });
 
 describe('constants', () => {

--- a/src/__tests__/concurrency.test.ts
+++ b/src/__tests__/concurrency.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { withConcurrencyLimit, DEFAULT_CONCURRENCY, DEFAULT_RUNNER_CONCURRENCY } from '../utils/concurrency.js';
+
+describe('withConcurrencyLimit', () => {
+  it('returns empty array for empty input', async () => {
+    const results = await withConcurrencyLimit([], 3);
+    expect(results).toEqual([]);
+  });
+
+  it('runs tasks sequentially with limit=1', async () => {
+    const order: number[] = [];
+    const factories = [0, 1, 2].map((i) => async () => {
+      order.push(i);
+      return i * 10;
+    });
+
+    const results = await withConcurrencyLimit(factories, 1);
+    expect(results).toEqual([0, 10, 20]);
+    expect(order).toEqual([0, 1, 2]);
+  });
+
+  it('respects bounded concurrency limit', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const limit = 2;
+
+    const factories = Array.from({ length: 5 }, (_, i) => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      // Yield to let other workers start if they can
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+      return i;
+    });
+
+    const results = await withConcurrencyLimit(factories, limit);
+    expect(results).toEqual([0, 1, 2, 3, 4]);
+    expect(maxActive).toBeLessThanOrEqual(limit);
+    expect(maxActive).toBe(limit);
+  });
+
+  it('runs all tasks at once with limit=0 (unlimited)', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const count = 5;
+
+    const factories = Array.from({ length: count }, (_, i) => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+      return i;
+    });
+
+    const results = await withConcurrencyLimit(factories, 0);
+    expect(results).toEqual([0, 1, 2, 3, 4]);
+    expect(maxActive).toBe(count);
+  });
+
+  it('preserves result order regardless of completion order', async () => {
+    // Tasks complete in reverse order but results should match input order
+    const factories = [0, 1, 2, 3].map((i) => async () => {
+      await new Promise((r) => setTimeout(r, (3 - i) * 10));
+      return `task-${i}`;
+    });
+
+    const results = await withConcurrencyLimit(factories, 4);
+    expect(results).toEqual(['task-0', 'task-1', 'task-2', 'task-3']);
+  });
+
+  it('propagates errors from failing factories', async () => {
+    const factories = [
+      async () => 'ok',
+      async () => { throw new Error('boom'); },
+      async () => 'also ok',
+    ];
+
+    await expect(withConcurrencyLimit(factories, 2)).rejects.toThrow('boom');
+  });
+
+  it('handles limit larger than factory count', async () => {
+    const factories = [async () => 1, async () => 2];
+    const results = await withConcurrencyLimit(factories, 100);
+    expect(results).toEqual([1, 2]);
+  });
+});
+
+describe('constants', () => {
+  it('DEFAULT_CONCURRENCY is 5 (for judge)', () => {
+    expect(DEFAULT_CONCURRENCY).toBe(5);
+  });
+
+  it('DEFAULT_RUNNER_CONCURRENCY is 1 (sequential)', () => {
+    expect(DEFAULT_RUNNER_CONCURRENCY).toBe(1);
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import * as os from 'os';
-import { loadConfig } from '../config.js';
+import { loadConfig, DEFAULT_CONFIG } from '../config.js';
 
 describe('loadConfig', () => {
   const tmpDirs: string[] = [];
@@ -116,5 +116,69 @@ describe('loadConfig htmlReport', () => {
 
     const config = await loadConfig(configPath, { htmlReport: true });
     expect(config.htmlReport).toBe(true);
+  });
+});
+
+describe('concurrency config', () => {
+  const tmpDirs: string[] = [];
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.EVAL_RUNNER_CONCURRENCY;
+    delete process.env.EVAL_RUNNER_CONCURRENCY;
+  });
+
+  afterEach(async () => {
+    if (savedEnv !== undefined) {
+      process.env.EVAL_RUNNER_CONCURRENCY = savedEnv;
+    } else {
+      delete process.env.EVAL_RUNNER_CONCURRENCY;
+    }
+    for (const dir of tmpDirs) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+    tmpDirs.length = 0;
+  });
+
+  it('defaults concurrency to 1 (sequential)', async () => {
+    expect(DEFAULT_CONFIG.concurrency).toBe(1);
+    const config = await loadConfig('/nonexistent/path/eval.config.yaml');
+    expect(config.concurrency).toBe(1);
+  });
+
+  it('loads concurrency from EVAL_RUNNER_CONCURRENCY env var', async () => {
+    process.env.EVAL_RUNNER_CONCURRENCY = '5';
+    const config = await loadConfig('/nonexistent/path/eval.config.yaml');
+    expect(config.concurrency).toBe(5);
+  });
+
+  it('loads concurrency=0 (unlimited) from env var', async () => {
+    process.env.EVAL_RUNNER_CONCURRENCY = '0';
+    const config = await loadConfig('/nonexistent/path/eval.config.yaml');
+    expect(config.concurrency).toBe(0);
+  });
+
+  it('ignores negative EVAL_RUNNER_CONCURRENCY', async () => {
+    process.env.EVAL_RUNNER_CONCURRENCY = '-1';
+    const config = await loadConfig('/nonexistent/path/eval.config.yaml');
+    expect(config.concurrency).toBe(1); // default
+  });
+
+  it('loads concurrency from YAML config', async () => {
+    const tmpDir = path.join(os.tmpdir(), `eval-test-concurrency-${Date.now()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    tmpDirs.push(tmpDir);
+
+    const configPath = path.join(tmpDir, 'eval.config.yaml');
+    await fs.writeFile(configPath, 'runner:\n  concurrency: 3\n');
+
+    const config = await loadConfig(configPath);
+    expect(config.concurrency).toBe(3);
+  });
+
+  it('CLI override takes precedence over env var', async () => {
+    process.env.EVAL_RUNNER_CONCURRENCY = '5';
+    const config = await loadConfig('/nonexistent/path/eval.config.yaml', { concurrency: 2 });
+    expect(config.concurrency).toBe(2);
   });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -192,4 +192,15 @@ describe('concurrency config', () => {
 
     await expect(loadConfig(configPath)).rejects.toThrow('Invalid runner.concurrency');
   });
+
+  it('throws on non-integer concurrency in YAML config', async () => {
+    const tmpDir = path.join(os.tmpdir(), `eval-test-concurrency-float-${Date.now()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    tmpDirs.push(tmpDir);
+
+    const configPath = path.join(tmpDir, 'eval.config.yaml');
+    await fs.writeFile(configPath, 'runner:\n  concurrency: 2.5\n');
+
+    await expect(loadConfig(configPath)).rejects.toThrow('Must be a non-negative integer');
+  });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -181,4 +181,15 @@ describe('concurrency config', () => {
     const config = await loadConfig('/nonexistent/path/eval.config.yaml', { concurrency: 2 });
     expect(config.concurrency).toBe(2);
   });
+
+  it('throws on negative concurrency in YAML config', async () => {
+    const tmpDir = path.join(os.tmpdir(), `eval-test-concurrency-neg-${Date.now()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    tmpDirs.push(tmpDir);
+
+    const configPath = path.join(tmpDir, 'eval.config.yaml');
+    await fs.writeFile(configPath, 'runner:\n  concurrency: -3\n');
+
+    await expect(loadConfig(configPath)).rejects.toThrow('Invalid runner.concurrency');
+  });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -158,10 +158,14 @@ describe('concurrency config', () => {
     expect(config.concurrency).toBe(0);
   });
 
-  it('ignores negative EVAL_RUNNER_CONCURRENCY', async () => {
+  it('throws on negative EVAL_RUNNER_CONCURRENCY', async () => {
     process.env.EVAL_RUNNER_CONCURRENCY = '-1';
-    const config = await loadConfig('/nonexistent/path/eval.config.yaml');
-    expect(config.concurrency).toBe(1); // default
+    await expect(loadConfig('/nonexistent/path/eval.config.yaml')).rejects.toThrow('Must be a non-negative integer');
+  });
+
+  it('throws on non-integer EVAL_RUNNER_CONCURRENCY', async () => {
+    process.env.EVAL_RUNNER_CONCURRENCY = '2.5';
+    await expect(loadConfig('/nonexistent/path/eval.config.yaml')).rejects.toThrow('Must be a non-negative integer');
   });
 
   it('loads concurrency from YAML config', async () => {

--- a/src/__tests__/runner-factory.test.ts
+++ b/src/__tests__/runner-factory.test.ts
@@ -47,4 +47,29 @@ describe('createRunner', () => {
     expect(opts.cwd).toBe('/tmp/test');
     expect(opts.taskTimeoutMs).toBe(60000);
   });
+
+  it('passes concurrency option through to runner', async () => {
+    const runner = await createRunner('claude-sdk', {
+      concurrency: 3,
+    });
+    const opts = (runner as any).runnerOptions;
+    expect(opts.concurrency).toBe(3);
+  });
+
+  it('maps parallel: true to concurrency: 0 for backward compat', async () => {
+    const runner = await createRunner('claude-sdk', {
+      parallel: true,
+    });
+    const opts = (runner as any).runnerOptions;
+    expect(opts.concurrency).toBe(0);
+  });
+
+  it('explicit concurrency takes precedence over parallel', async () => {
+    const runner = await createRunner('claude-sdk', {
+      parallel: true,
+      concurrency: 5,
+    });
+    const opts = (runner as any).runnerOptions;
+    expect(opts.concurrency).toBe(5);
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,9 +111,9 @@ program
       if (options.githubSummary) configOverrides.githubSummary = true;
       if (options.html !== undefined) configOverrides.htmlReport = options.html;
       if (options.concurrency !== undefined) {
-        const c = parseInt(options.concurrency, 10);
-        if (isNaN(c) || c < 0) {
-          console.error('Error: --concurrency must be an integer >= 0');
+        const c = Number(options.concurrency);
+        if (!Number.isInteger(c) || c < 0) {
+          console.error('Error: --concurrency must be a non-negative integer');
           process.exit(1);
         }
         configOverrides.concurrency = c;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,7 @@ program
   .option('--threshold-score <score>', 'Min avg score (1-5)')
   .option('--no-judge', 'Skip LLM judge scoring (deterministic only)')
   .option('--no-deterministic', 'Skip deterministic scoring (LLM judge only)')
+  .option('--concurrency <number>', 'Max concurrent tasks (1=sequential, 0=unlimited)')
   .option('--runs <number>', 'Number of times to run each task (default: 3)')
   .option('--generate-feedback <path>', 'Generate feedback template JSON with task IDs after run')
   .option('--feedback <path>', 'Path to human review feedback JSON for judge prompt enrichment')
@@ -78,6 +79,7 @@ program
     thresholdScore?: string;
     judge?: boolean;
     deterministic?: boolean;
+    concurrency?: string;
     runs?: string;
     generateFeedback?: string;
     feedback?: string;
@@ -108,6 +110,14 @@ program
       if (options.thresholdScore) configOverrides.scoreThreshold = parseFloat(options.thresholdScore);
       if (options.githubSummary) configOverrides.githubSummary = true;
       if (options.html !== undefined) configOverrides.htmlReport = options.html;
+      if (options.concurrency) {
+        const c = parseInt(options.concurrency, 10);
+        if (isNaN(c) || c < 0) {
+          console.error('Error: --concurrency must be an integer >= 0');
+          process.exit(1);
+        }
+        configOverrides.concurrency = c;
+      }
 
       const result = await runPipeline({
         tasksFile,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,7 +110,7 @@ program
       if (options.thresholdScore) configOverrides.scoreThreshold = parseFloat(options.thresholdScore);
       if (options.githubSummary) configOverrides.githubSummary = true;
       if (options.html !== undefined) configOverrides.htmlReport = options.html;
-      if (options.concurrency) {
+      if (options.concurrency !== undefined) {
         const c = parseInt(options.concurrency, 10);
         if (isNaN(c) || c < 0) {
           console.error('Error: --concurrency must be an integer >= 0');

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,9 @@ export interface EvalConfig {
   // Timeouts
   taskTimeoutMs: number;
 
+  // Concurrency
+  concurrency: number;
+
   // CI/CD behavior
   exitOnFailure: boolean;
   outputDir: string;
@@ -78,6 +81,7 @@ export const DEFAULT_CONFIG: EvalConfig = {
   judgeOutputTruncation: 5000,
   reportOutputTruncation: 2000,
   taskTimeoutMs: 300000, // 5 minutes
+  concurrency: 1, // sequential by default
   exitOnFailure: true,
   outputDir: './results',
   githubSummary: false,
@@ -114,6 +118,7 @@ interface RawConfigFile {
   runner?: {
     type?: string;
     timeout_ms?: number;
+    concurrency?: number;
     allowed_write_dirs?: string[];
   };
   output?: {
@@ -167,6 +172,7 @@ async function loadConfigFile(configPath?: string): Promise<Partial<EvalConfig>>
     if (raw.thresholds?.avg_score !== undefined) config.scoreThreshold = raw.thresholds.avg_score;
 
     if (raw.runner?.timeout_ms !== undefined) config.taskTimeoutMs = raw.runner.timeout_ms;
+    if (raw.runner?.concurrency !== undefined) config.concurrency = raw.runner.concurrency;
     if (raw.runner?.allowed_write_dirs) config.allowedWriteDirs = raw.runner.allowed_write_dirs;
 
     if (raw.output?.dir) config.outputDir = raw.output.dir;
@@ -236,6 +242,9 @@ function loadEnvConfig(): Partial<EvalConfig> {
   const timeout = parseInt(process.env.EVAL_TASK_TIMEOUT_MS || '', 10);
   if (!isNaN(timeout)) config.taskTimeoutMs = timeout;
 
+  const concurrency = parseInt(process.env.EVAL_RUNNER_CONCURRENCY || '', 10);
+  if (!isNaN(concurrency) && concurrency >= 0) config.concurrency = concurrency;
+
   if (process.env.EVAL_EXIT_ON_FAILURE !== undefined) {
     config.exitOnFailure = process.env.EVAL_EXIT_ON_FAILURE !== 'false';
   }
@@ -292,6 +301,7 @@ function mergeConfigs(...configs: Partial<EvalConfig>[]): EvalConfig {
     if (config.judgeOutputTruncation !== undefined) result.judgeOutputTruncation = config.judgeOutputTruncation;
     if (config.reportOutputTruncation !== undefined) result.reportOutputTruncation = config.reportOutputTruncation;
     if (config.taskTimeoutMs !== undefined) result.taskTimeoutMs = config.taskTimeoutMs;
+    if (config.concurrency !== undefined) result.concurrency = config.concurrency;
     if (config.exitOnFailure !== undefined) result.exitOnFailure = config.exitOnFailure;
     if (config.outputDir !== undefined) result.outputDir = config.outputDir;
     if (config.githubSummary !== undefined) result.githubSummary = config.githubSummary;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@
 import yaml from 'js-yaml';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { DEFAULT_RUNNER_CONCURRENCY } from './utils/concurrency.js';
 
 export type RunnerType = 'claude-sdk' | 'vercel-ai' | 'openai-agents' | 'copilot-sdk';
 
@@ -81,7 +82,7 @@ export const DEFAULT_CONFIG: EvalConfig = {
   judgeOutputTruncation: 5000,
   reportOutputTruncation: 2000,
   taskTimeoutMs: 300000, // 5 minutes
-  concurrency: 1, // sequential by default
+  concurrency: DEFAULT_RUNNER_CONCURRENCY, // sequential by default
   exitOnFailure: true,
   outputDir: './results',
   githubSummary: false,
@@ -172,7 +173,12 @@ async function loadConfigFile(configPath?: string): Promise<Partial<EvalConfig>>
     if (raw.thresholds?.avg_score !== undefined) config.scoreThreshold = raw.thresholds.avg_score;
 
     if (raw.runner?.timeout_ms !== undefined) config.taskTimeoutMs = raw.runner.timeout_ms;
-    if (raw.runner?.concurrency !== undefined) config.concurrency = raw.runner.concurrency;
+    if (raw.runner?.concurrency !== undefined) {
+      if (raw.runner.concurrency < 0) {
+        throw new Error(`Invalid runner.concurrency "${raw.runner.concurrency}" in config file. Must be >= 0.`);
+      }
+      config.concurrency = raw.runner.concurrency;
+    }
     if (raw.runner?.allowed_write_dirs) config.allowedWriteDirs = raw.runner.allowed_write_dirs;
 
     if (raw.output?.dir) config.outputDir = raw.output.dir;
@@ -211,6 +217,7 @@ async function loadConfigFile(configPath?: string): Promise<Partial<EvalConfig>>
  * - EVAL_OUTPUT_TRUNCATION: Max chars to show judge (default: 5000)
  * - EVAL_REPORT_TRUNCATION: Max chars in reports (default: 2000)
  * - EVAL_TASK_TIMEOUT_MS: Per-task timeout in ms (default: 300000)
+ * - EVAL_RUNNER_CONCURRENCY: Max concurrent tasks (default: 1, 0=unlimited)
  * - EVAL_EXIT_ON_FAILURE: Exit with code 1 on failures (default: true)
  * - EVAL_OUTPUT_DIR: Directory for results (default: './results')
  * - EVAL_DISCOVERY_THRESHOLD: Min discovery rate 0-1 (default: 0.8)

--- a/src/config.ts
+++ b/src/config.ts
@@ -249,8 +249,14 @@ function loadEnvConfig(): Partial<EvalConfig> {
   const timeout = parseInt(process.env.EVAL_TASK_TIMEOUT_MS || '', 10);
   if (!isNaN(timeout)) config.taskTimeoutMs = timeout;
 
-  const concurrency = parseInt(process.env.EVAL_RUNNER_CONCURRENCY || '', 10);
-  if (!isNaN(concurrency) && concurrency >= 0) config.concurrency = concurrency;
+  const concurrencyRaw = process.env.EVAL_RUNNER_CONCURRENCY;
+  if (concurrencyRaw !== undefined && concurrencyRaw !== '') {
+    const concurrency = Number(concurrencyRaw);
+    if (!Number.isInteger(concurrency) || concurrency < 0) {
+      throw new Error(`Invalid EVAL_RUNNER_CONCURRENCY "${concurrencyRaw}". Must be a non-negative integer.`);
+    }
+    config.concurrency = concurrency;
+  }
 
   if (process.env.EVAL_EXIT_ON_FAILURE !== undefined) {
     config.exitOnFailure = process.env.EVAL_EXIT_ON_FAILURE !== 'false';

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,8 +174,8 @@ async function loadConfigFile(configPath?: string): Promise<Partial<EvalConfig>>
 
     if (raw.runner?.timeout_ms !== undefined) config.taskTimeoutMs = raw.runner.timeout_ms;
     if (raw.runner?.concurrency !== undefined) {
-      if (raw.runner.concurrency < 0) {
-        throw new Error(`Invalid runner.concurrency "${raw.runner.concurrency}" in config file. Must be >= 0.`);
+      if (!Number.isInteger(raw.runner.concurrency) || raw.runner.concurrency < 0) {
+        throw new Error(`Invalid runner.concurrency "${raw.runner.concurrency}" in config file. Must be a non-negative integer.`);
       }
       config.concurrency = raw.runner.concurrency;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,8 @@ export { createToolPolicy } from './runner/security.js';
 // Scorer
 export { scoreTask, scoreAll } from './scorer/scorer.js';
 export { scoreDeterministic } from './scorer/deterministic.js';
-export { SkillJudge, blindCompareAll, BLIND_BIAS_THRESHOLD, DEFAULT_CONCURRENCY } from './scorer/judge.js';
+export { SkillJudge, blindCompareAll, BLIND_BIAS_THRESHOLD } from './scorer/judge.js';
+export { DEFAULT_CONCURRENCY, DEFAULT_RUNNER_CONCURRENCY, withConcurrencyLimit } from './utils/concurrency.js';
 export type { BlindCompareOptions } from './scorer/judge.js';
 export { aggregateResults, aggregateScores, computeStddev, FLAKY_STDDEV_THRESHOLD, isFlaky } from './scorer/aggregator.js';
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -167,7 +167,7 @@ async function runPhase(
   const runner = await createRunner(config.runnerType, {
     cwd,
     model: config.defaultAgentModel,
-    parallel: false,
+    concurrency: config.concurrency,
     allowedWriteDirs: config.allowedWriteDirs,
     skillsDir,
   }, config);

--- a/src/runner/agent-runner.ts
+++ b/src/runner/agent-runner.ts
@@ -18,8 +18,13 @@ import type { SessionLogger } from '../session/session-logger.js';
 export interface AgentRunnerOptions {
   /** Working directory for agent execution */
   cwd?: string;
-  /** Run tasks in parallel */
+  /**
+   * Run tasks in parallel (unlimited concurrency).
+   * @deprecated Use `concurrency: 0` for unlimited parallelism instead.
+   */
   parallel?: boolean;
+  /** Max concurrent tasks. 1 = sequential (default), 0 = unlimited, N = bounded. */
+  concurrency?: number;
   /** Model identifier (format depends on runner) */
   model?: string;
   /** Per-task timeout in ms */

--- a/src/runner/base-runner.ts
+++ b/src/runner/base-runner.ts
@@ -14,7 +14,7 @@ import type {
 import { loadConfigSync } from '../config.js';
 import type { EvalConfig } from '../config.js';
 import type { SessionLogger } from '../session/session-logger.js';
-import { withConcurrencyLimit } from '../utils/concurrency.js';
+import { withConcurrencyLimit, DEFAULT_RUNNER_CONCURRENCY } from '../utils/concurrency.js';
 
 export abstract class BaseRunner implements AgentRunner {
   abstract readonly providerName: string;
@@ -38,7 +38,7 @@ export abstract class BaseRunner implements AgentRunner {
     this.options = {
       cwd: options.cwd ?? process.cwd(),
       parallel: options.parallel ?? false,
-      concurrency: options.concurrency ?? (options.parallel ? 0 : undefined) ?? resolvedConfig.concurrency ?? 1,
+      concurrency: options.concurrency ?? (options.parallel ? 0 : undefined) ?? resolvedConfig.concurrency ?? DEFAULT_RUNNER_CONCURRENCY,
       model: options.model ?? resolvedConfig.defaultAgentModel,
       taskTimeoutMs: options.taskTimeoutMs ?? resolvedConfig.taskTimeoutMs,
       allowedWriteDirs: options.allowedWriteDirs ?? resolvedConfig.allowedWriteDirs,

--- a/src/runner/base-runner.ts
+++ b/src/runner/base-runner.ts
@@ -38,6 +38,7 @@ export abstract class BaseRunner implements AgentRunner {
     this.options = {
       cwd: options.cwd ?? process.cwd(),
       parallel: options.parallel ?? false,
+      // Precedence: explicit concurrency > parallel (deprecated, maps to unlimited) > config file > default (1)
       concurrency: options.concurrency ?? (options.parallel ? 0 : undefined) ?? resolvedConfig.concurrency ?? DEFAULT_RUNNER_CONCURRENCY,
       model: options.model ?? resolvedConfig.defaultAgentModel,
       taskTimeoutMs: options.taskTimeoutMs ?? resolvedConfig.taskTimeoutMs,

--- a/src/runner/base-runner.ts
+++ b/src/runner/base-runner.ts
@@ -37,7 +37,6 @@ export abstract class BaseRunner implements AgentRunner {
 
     this.options = {
       cwd: options.cwd ?? process.cwd(),
-      parallel: options.parallel ?? false,
       // Precedence: explicit concurrency > parallel (deprecated, maps to unlimited) > config file > default (1)
       concurrency: options.concurrency ?? (options.parallel ? 0 : undefined) ?? resolvedConfig.concurrency ?? DEFAULT_RUNNER_CONCURRENCY,
       model: options.model ?? resolvedConfig.defaultAgentModel,

--- a/src/runner/base-runner.ts
+++ b/src/runner/base-runner.ts
@@ -14,6 +14,7 @@ import type {
 import { loadConfigSync } from '../config.js';
 import type { EvalConfig } from '../config.js';
 import type { SessionLogger } from '../session/session-logger.js';
+import { withConcurrencyLimit } from '../utils/concurrency.js';
 
 export abstract class BaseRunner implements AgentRunner {
   abstract readonly providerName: string;
@@ -37,6 +38,7 @@ export abstract class BaseRunner implements AgentRunner {
     this.options = {
       cwd: options.cwd ?? process.cwd(),
       parallel: options.parallel ?? false,
+      concurrency: options.concurrency ?? (options.parallel ? 0 : undefined) ?? resolvedConfig.concurrency ?? 1,
       model: options.model ?? resolvedConfig.defaultAgentModel,
       taskTimeoutMs: options.taskTimeoutMs ?? resolvedConfig.taskTimeoutMs,
       allowedWriteDirs: options.allowedWriteDirs ?? resolvedConfig.allowedWriteDirs,
@@ -117,44 +119,38 @@ export abstract class BaseRunner implements AgentRunner {
 
   /**
    * Run all tasks in an evaluation suite.
+   *
+   * Concurrency is controlled by `options.concurrency`:
+   * - 1 = sequential (default)
+   * - 0 = unlimited
+   * - N = at most N tasks in flight
    */
   async runAll(
     evaluation: SkillEvaluation,
     createLogger?: (task: EvalTask) => SessionLogger,
   ): Promise<TaskResult[]> {
-    if (this.options.parallel) {
-      const results = await Promise.allSettled(
-        evaluation.tasks.map((task) => {
-          const logger = createLogger?.(task);
-          return this.runTaskWithTimeout(task, undefined, logger);
-        }),
-      );
+    const limit = this.options.concurrency ?? 1;
 
-      return results.map((result, i) => {
-        if (result.status === 'fulfilled') {
-          return result.value;
+    const factories = evaluation.tasks.map((task) => async () => {
+      console.log(`Running task ${task.id}: ${task.prompt.length > 60 ? task.prompt.slice(0, 60) + '...' : task.prompt}`);
+      try {
+        const logger = createLogger?.(task);
+        const result = await this.runTaskWithTimeout(task, undefined, logger);
+
+        if (result.isError) {
+          console.error(`  Task ${task.id} ERROR: ${result.errorMessage}`);
+        } else {
+          console.log(`  Task ${task.id} done — Skills loaded: ${result.skillLoads.join(', ') || 'none'}`);
+          console.log(`  Duration: ${(result.durationMs / 1000).toFixed(1)}s | Cost: $${result.costUsd.toFixed(4)}`);
         }
-        const task = evaluation.tasks[i];
-        const errMsg = result.reason?.message || 'Unknown error';
+        return result;
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
         console.error(`  Task ${task.id} ERROR: ${errMsg}`);
         return this.createErrorResult(task, errMsg, 0);
-      });
-    }
-
-    const results: TaskResult[] = [];
-    for (const task of evaluation.tasks) {
-      console.log(`Running task ${task.id}: ${task.prompt.length > 60 ? task.prompt.slice(0, 60) + '...' : task.prompt}`);
-      const logger = createLogger?.(task);
-      const result = await this.runTaskWithTimeout(task, undefined, logger);
-      results.push(result);
-
-      if (result.isError) {
-        console.error(`  ERROR: ${result.errorMessage}`);
-      } else {
-        console.log(`  Skills loaded: ${result.skillLoads.join(', ') || 'none'}`);
-        console.log(`  Duration: ${(result.durationMs / 1000).toFixed(1)}s | Cost: $${result.costUsd.toFixed(4)}`);
       }
-    }
-    return results;
+    });
+
+    return withConcurrencyLimit(factories, limit);
   }
 }

--- a/src/scorer/judge.ts
+++ b/src/scorer/judge.ts
@@ -28,6 +28,7 @@ import {
 } from '../types.js';
 import { getFeedbackForTask } from '../feedback.js';
 import { loadConfigSync } from '../config.js';
+import { withConcurrencyLimit, DEFAULT_CONCURRENCY } from '../utils/concurrency.js';
 
 const JUDGE_PROMPT_TEMPLATE = `You are an expert evaluator for AI agent skills. Score this skill evaluation result.
 
@@ -758,32 +759,6 @@ export async function blindCompareAll(
   };
 
   return { tasks: blindTasks, aggregate };
-}
-
-/** Default maximum number of concurrent API calls to the judge. */
-export const DEFAULT_CONCURRENCY = 5;
-
-/**
- * Run async tasks with a concurrency limit.
- */
-async function withConcurrencyLimit<T>(
-  factories: Array<() => Promise<T>>,
-  limit = DEFAULT_CONCURRENCY,
-): Promise<T[]> {
-  const results: T[] = new Array(factories.length);
-  let next = 0;
-
-  async function worker(): Promise<void> {
-    while (next < factories.length) {
-      // Safe: JS is single-threaded; `next++` is atomic relative to the event loop.
-      const idx = next++;
-      results[idx] = await factories[idx]();
-    }
-  }
-
-  const workers = Array.from({ length: Math.min(limit, factories.length) }, () => worker());
-  await Promise.all(workers);
-  return results;
 }
 
 function capitalize(s: string): string {

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -14,6 +14,9 @@ export const DEFAULT_RUNNER_CONCURRENCY = 1;
 /**
  * Run async tasks with a concurrency limit.
  *
+ * Note: if a factory throws, remaining in-flight workers are NOT cancelled.
+ * Callers that need graceful shutdown should catch inside each factory.
+ *
  * @param factories - Array of zero-argument async functions to execute.
  * @param limit - Max concurrent tasks. 1 = sequential, 0 = unlimited, N = bounded.
  * @returns Results in the same order as the input factories.

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -27,8 +27,12 @@ export async function withConcurrencyLimit<T>(
 ): Promise<T[]> {
   if (factories.length === 0) return [];
 
-  // Handle unlimited: if limit <= 0, run all at once
-  const effectiveLimit = limit <= 0 ? factories.length : limit;
+  if (limit < 0) {
+    throw new RangeError(`Concurrency limit must be >= 0, got ${limit}`);
+  }
+
+  // Handle unlimited: if limit === 0, run all at once
+  const effectiveLimit = limit === 0 ? factories.length : limit;
 
   const results: T[] = new Array(factories.length);
   let next = 0;

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared concurrency utilities.
+ *
+ * Provides a generic bounded-concurrency runner used by both the task runner
+ * (BaseRunner.runAll) and the scorer (SkillJudge.judgeAll / blindCompareAll).
+ */
+
+/** Default maximum number of concurrent API calls to the judge. */
+export const DEFAULT_CONCURRENCY = 5;
+
+/** Default runner concurrency (sequential execution). */
+export const DEFAULT_RUNNER_CONCURRENCY = 1;
+
+/**
+ * Run async tasks with a concurrency limit.
+ *
+ * @param factories - Array of zero-argument async functions to execute.
+ * @param limit - Max concurrent tasks. 1 = sequential, 0 = unlimited, N = bounded.
+ * @returns Results in the same order as the input factories.
+ */
+export async function withConcurrencyLimit<T>(
+  factories: Array<() => Promise<T>>,
+  limit = DEFAULT_CONCURRENCY,
+): Promise<T[]> {
+  if (factories.length === 0) return [];
+
+  // Handle unlimited: if limit <= 0, run all at once
+  const effectiveLimit = limit <= 0 ? factories.length : limit;
+
+  const results: T[] = new Array(factories.length);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < factories.length) {
+      // Safe: JS is single-threaded; `next++` is atomic relative to the event loop.
+      const idx = next++;
+      results[idx] = await factories[idx]();
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(effectiveLimit, factories.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}


### PR DESCRIPTION
## Summary

- Add `--concurrency N` CLI flag and `runner.concurrency` config option (YAML, env `EVAL_RUNNER_CONCURRENCY`) to control how many tasks run in parallel — `1` = sequential (default), `0` = unlimited, `N` = bounded
- Extract `withConcurrencyLimit` from `judge.ts` into shared `src/utils/concurrency.ts` and reuse in `BaseRunner.runAll`
- Deprecate the boolean `parallel` option in favor of `concurrency` (backward-compat: `parallel: true` maps to `concurrency: 0`)
- Add `concurrency` input to GitHub Action

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 249 tests pass (17 files), including 9 new tests for concurrency config, runner options, and the shared utility
- [x] `npm run build` compiles cleanly
- [ ] Manual: `skilljack-evals run evals/example-greeting/tasks.yaml --concurrency 2` runs with bounded concurrency

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)