### PR TITLE
Add per-task token consumption tracking

### DIFF
--- a/action/dist/index.cjs
+++ b/action/dist/index.cjs
@@ -23160,8 +23160,8 @@ ${skillsPrompt}` : "You are a helpful AI assistant.";
           let tokens;
           let totalForCost = 0;
           if (rawUsage) {
-            const input = rawUsage.promptTokens ?? 0;
-            const output2 = rawUsage.completionTokens ?? 0;
+            const input = rawUsage.inputTokens ?? 0;
+            const output2 = rawUsage.outputTokens ?? 0;
             const cacheRead = 0;
             const cacheCreation = 0;
             tokens = {
@@ -47535,7 +47535,7 @@ function costImpact(delta) {
     return "Lower";
   return "Similar";
 }
-var TOKEN_IMPACT_THRESHOLD = 100;
+var TOKEN_IMPACT_THRESHOLD = 1e3;
 function tokenImpact(delta) {
   if (delta > TOKEN_IMPACT_THRESHOLD)
     return "Higher";
@@ -47939,7 +47939,7 @@ function renderComparisonSection(comparison) {
       <td>${w.adherence.toFixed(1)} / ${b.adherence.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.adherenceDelta, 1))}</span></td>
       <td>${w.outputQuality.toFixed(1)} / ${b.outputQuality.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.outputQualityDelta, 1))}</span></td>
       <td>${w.weightedScore.toFixed(2)} / ${b.weightedScore.toFixed(2)} / <span class="delta">${escapeHtml(formatDelta(t.delta.weightedScoreDelta))}</span></td>
-      <td data-sort="${t.delta.totalTokensDelta ?? 0}">${tokenCell}</td>
+      <td>${tokenCell}</td>
     </tr>`;
   }
   return `

--- a/action/dist/index.cjs
+++ b/action/dist/index.cjs
@@ -22817,7 +22817,8 @@ var init_base_runner = __esm({
           skillLoads: [...new Set(fields.skillLoads)],
           toolCalls: fields.toolCalls,
           isError: false,
-          errorMessage: ""
+          errorMessage: "",
+          tokens: fields.tokens
         };
       }
       /**
@@ -23155,16 +23156,30 @@ ${skillsPrompt}` : "You are a helpful AI assistant.";
           });
           const output = result.text ?? "";
           logger?.addTextMessage(output);
-          const usage = result.usage ?? { promptTokens: 0, completionTokens: 0 };
-          const totalTokens = (usage.promptTokens ?? 0) + (usage.completionTokens ?? 0);
-          const costUsd = totalTokens * 3e-6;
+          const rawUsage = result.usage;
+          let tokens;
+          let totalForCost = 0;
+          if (rawUsage) {
+            const input = rawUsage.promptTokens ?? 0;
+            const output2 = rawUsage.completionTokens ?? 0;
+            tokens = {
+              input,
+              output: output2,
+              cacheRead: 0,
+              cacheCreation: 0,
+              total: input + output2
+            };
+            totalForCost = input + output2;
+          }
+          const costUsd = totalForCost * 3e-6;
           return this.buildTaskResult(task, {
             output,
             durationMs: Date.now() - startTime,
             numTurns: stepCount,
             costUsd,
             skillLoads,
-            toolCalls
+            toolCalls,
+            tokens
           });
         } catch (error2) {
           return this.handleRunError(task, error2, startTime, logger);
@@ -23344,15 +23359,29 @@ var init_openai_agents_runner = __esm({
           }
           const skillLoads = detectSkillLoadsFromShellCommands(shellCommands, localSkills);
           const usage = result.usage;
-          const totalTokens = (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0);
-          const costUsd = totalTokens * 3e-6;
+          let tokens;
+          let totalForCost = 0;
+          if (usage) {
+            const input = usage.inputTokens ?? 0;
+            const output2 = usage.outputTokens ?? 0;
+            tokens = {
+              input,
+              output: output2,
+              cacheRead: 0,
+              cacheCreation: 0,
+              total: input + output2
+            };
+            totalForCost = input + output2;
+          }
+          const costUsd = totalForCost * 3e-6;
           return this.buildTaskResult(task, {
             output: typeof output === "string" ? output : JSON.stringify(output),
             durationMs: Date.now() - startTime,
             numTurns,
             costUsd,
             skillLoads,
-            toolCalls
+            toolCalls,
+            tokens
           });
         } catch (error2) {
           return this.handleRunError(task, error2, startTime, logger);
@@ -45576,6 +45605,7 @@ var ClaudeSdkRunner = class extends BaseRunner {
       let resultDurationMs = 0;
       let resultNumTurns = 0;
       let resultCostUsd = 0;
+      let resultTokens;
       const toolPolicy = createToolPolicy(this.options.allowedWriteDirs ?? [], this.options.cwd ?? process.cwd());
       const q = query({
         prompt: task.prompt,
@@ -45639,6 +45669,20 @@ var ClaudeSdkRunner = class extends BaseRunner {
           resultDurationMs = message.duration_ms ?? 0;
           resultNumTurns = message.num_turns ?? 0;
           resultCostUsd = message.total_cost_usd ?? 0;
+          const u = message.usage;
+          if (u) {
+            const input = u.input_tokens ?? 0;
+            const output = u.output_tokens ?? 0;
+            const cacheRead = u.cache_read_input_tokens ?? 0;
+            const cacheCreation = u.cache_creation_input_tokens ?? 0;
+            resultTokens = {
+              input,
+              output,
+              cacheRead,
+              cacheCreation,
+              total: input + output + cacheRead + cacheCreation
+            };
+          }
           if (message.result) {
             resultOutput = message.result;
           }
@@ -45650,7 +45694,8 @@ var ClaudeSdkRunner = class extends BaseRunner {
         numTurns: resultNumTurns,
         costUsd: resultCostUsd,
         skillLoads,
-        toolCalls
+        toolCalls,
+        tokens: resultTokens
       });
     } catch (error2) {
       return this.handleRunError(task, error2, startTime, logger);
@@ -46824,6 +46869,14 @@ function aggregateResults(allResults, allScores) {
     const scores = allScores.map((s) => s[t]);
     const repIdx = findRepresentativeIndex(scores);
     const rep = runs[repIdx];
+    const allHaveTokens = runs.every((r) => r.tokens);
+    const tokens = allHaveTokens ? {
+      input: runs.reduce((s, r) => s + r.tokens.input, 0),
+      output: runs.reduce((s, r) => s + r.tokens.output, 0),
+      cacheRead: runs.reduce((s, r) => s + r.tokens.cacheRead, 0),
+      cacheCreation: runs.reduce((s, r) => s + r.tokens.cacheCreation, 0),
+      total: runs.reduce((s, r) => s + r.tokens.total, 0)
+    } : void 0;
     aggregated.push({
       taskId: rep.taskId,
       prompt: rep.prompt,
@@ -46834,7 +46887,8 @@ function aggregateResults(allResults, allScores) {
       skillLoads: [...new Set(runs.flatMap((r) => r.skillLoads))],
       toolCalls: rep.toolCalls,
       isError: runs.some((r) => r.isError),
-      errorMessage: runs.filter((r) => r.isError).map((r) => r.errorMessage).join("; ")
+      errorMessage: runs.filter((r) => r.isError).map((r) => r.errorMessage).join("; "),
+      tokens
     });
   }
   return aggregated;
@@ -47150,6 +47204,7 @@ ${metaSection}
 | **Avg Weighted Score** | ${summary2.avgWeightedScore.toFixed(2)}${summary2.stddev ? ` \xB1 ${summary2.stddev.weightedScore.toFixed(2)}` : ""} | | |
 | **Total Duration** | ${(summary2.totalDurationMs / 1e3).toFixed(1)}s | | |
 | **Total Cost** | $${summary2.totalCostUsd.toFixed(4)} | | |
+| **Total Tokens** | ${summary2.totalTokens !== void 0 ? summary2.totalTokens.toLocaleString() : "n/a"} | | |
 
 ## Failure Analysis
 
@@ -47270,20 +47325,21 @@ ${result.output.slice(0, config2.reportOutputTruncation) || "(no output)"}
 
 </details>
 
-**Metrics:** Duration: ${(result.durationMs / 1e3).toFixed(1)}s | Turns: ${result.numTurns} | Cost: $${result.costUsd.toFixed(4)}
+**Metrics:** Duration: ${(result.durationMs / 1e3).toFixed(1)}s | Turns: ${result.numTurns} | Cost: $${result.costUsd.toFixed(4)} | Tokens: ${result.tokens ? result.tokens.total.toLocaleString() : "n/a"}
 `;
     if (runDetails && runDetails[i] && runDetails[i].length > 1) {
       report += `
 <details>
 <summary>Per-run breakdown (${runDetails[i].length} runs)</summary>
 
-| Run | Discovery | Adherence | Output | Weighted | Skills Loaded |
-|-----|-----------|-----------|--------|----------|---------------|
+| Run | Discovery | Adherence | Output | Weighted | Tokens | Skills Loaded |
+|-----|-----------|-----------|--------|----------|--------|---------------|
 `;
       for (let r = 0; r < runDetails[i].length; r++) {
         const rd = runDetails[i][r];
         const skills = rd.result.skillLoads.length > 0 ? rd.result.skillLoads.join(", ") : "none";
-        report += `| ${r + 1} | ${rd.score.discovery} | ${rd.score.adherence}/5 | ${rd.score.outputQuality}/5 | ${rd.score.weightedScore.toFixed(2)} | ${skills} |
+        const runTokens = rd.result.tokens ? rd.result.tokens.total.toLocaleString() : "n/a";
+        report += `| ${r + 1} | ${rd.score.discovery} | ${rd.score.adherence}/5 | ${rd.score.outputQuality}/5 | ${rd.score.weightedScore.toFixed(2)} | ${runTokens} | ${skills} |
 `;
       }
       report += `
@@ -47374,6 +47430,8 @@ function computeSummary(results, scores, numRuns = 1) {
   const avgAdherence = totalTasks > 0 ? scores.reduce((sum, s) => sum + s.adherence, 0) / totalTasks : 0;
   const avgOutputQuality = totalTasks > 0 ? scores.reduce((sum, s) => sum + s.outputQuality, 0) / totalTasks : 0;
   const avgWeightedScore = totalTasks > 0 ? scores.reduce((sum, s) => sum + s.weightedScore, 0) / totalTasks : 0;
+  const allHaveTokens = results.length > 0 && results.every((r) => r.tokens);
+  const totalTokens = allHaveTokens ? results.reduce((sum, r) => sum + r.tokens.total, 0) : void 0;
   const summary2 = {
     totalTasks,
     numRuns,
@@ -47382,7 +47440,8 @@ function computeSummary(results, scores, numRuns = 1) {
     avgOutputQuality,
     avgWeightedScore,
     totalDurationMs: results.reduce((sum, r) => sum + r.durationMs, 0),
-    totalCostUsd: results.reduce((sum, r) => sum + r.costUsd, 0)
+    totalCostUsd: results.reduce((sum, r) => sum + r.costUsd, 0),
+    totalTokens
   };
   if (numRuns >= 2) {
     const tasksWithStddev = scores.filter((s) => s.stddev);
@@ -47430,6 +47489,7 @@ function generateComparisonSection(comparison) {
 | Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | ${formatDelta(d.avgWeightedScoreDelta)} | ${qualityImpact(d.avgWeightedScoreDelta, WEIGHTED_SCORE_IMPACT_THRESHOLD)} |
 | Duration | ${(ws.totalDurationMs / 1e3).toFixed(1)}s | ${(bs.totalDurationMs / 1e3).toFixed(1)}s | ${formatDelta(d.totalDurationDeltaMs / 1e3, 1)}s | ${durationImpact(d.totalDurationDeltaMs)} |
 | Cost | $${ws.totalCostUsd.toFixed(4)} | $${bs.totalCostUsd.toFixed(4)} | $${formatDelta(d.totalCostDeltaUsd, 4)} | ${costImpact(d.totalCostDeltaUsd)} |
+| Tokens | ${ws.totalTokens !== void 0 ? ws.totalTokens.toLocaleString() : "n/a"} | ${bs.totalTokens !== void 0 ? bs.totalTokens.toLocaleString() : "n/a"} | ${d.totalTokensDelta !== void 0 ? formatDelta(d.totalTokensDelta, 0) : "n/a"} | ${d.totalTokensDelta !== void 0 ? tokenImpact(d.totalTokensDelta) : ""} |
 
 ### Per-Task Comparison
 
@@ -47468,6 +47528,14 @@ function costImpact(delta) {
   if (delta > COST_IMPACT_THRESHOLD_USD)
     return "Higher";
   if (delta < -COST_IMPACT_THRESHOLD_USD)
+    return "Lower";
+  return "Similar";
+}
+var TOKEN_IMPACT_THRESHOLD = 100;
+function tokenImpact(delta) {
+  if (delta > TOKEN_IMPACT_THRESHOLD)
+    return "Higher";
+  if (delta < -TOKEN_IMPACT_THRESHOLD)
     return "Lower";
   return "Similar";
 }
@@ -47548,7 +47616,8 @@ async function generateHtmlReport(options) {
     outputQuality: t.score.outputQuality,
     weightedScore: t.score.weightedScore,
     failureCategory: t.score.failureCategory,
-    isFlaky: isFlaky(t.score.stddev)
+    isFlaky: isFlaky(t.score.stddev),
+    tokens: t.result.tokens?.total ?? null
   }));
   const regressedTaskIds = new Set(crossIterationComparison?.taskDeltas.filter((d) => d.significantChange === "regressed").map((d) => d.taskId) ?? []);
   const clientDataWithRegression = clientData.map((d) => ({
@@ -47663,6 +47732,10 @@ function renderDashboard(summary2, config2) {
       <div class="stat-value">$${summary2.totalCostUsd.toFixed(4)}</div>
       <div class="stat-label">Cost</div>
     </div>
+    <div class="stat">
+      <div class="stat-value">${summary2.totalTokens !== void 0 ? summary2.totalTokens.toLocaleString() : "&mdash;"}</div>
+      <div class="stat-label">Tokens</div>
+    </div>
   </div>
 </section>`;
 }
@@ -47709,6 +47782,7 @@ function renderTaskTable(tasks, config2, humanFeedback) {
     const flaky = isFlaky(t.score.stddev);
     const statusClass = isFailed ? "status-fail" : flaky ? "status-flaky" : "status-pass";
     const statusLabel = isFailed ? "FAIL" : flaky ? "FLAKY" : "PASS";
+    const tokensCell = t.result.tokens ? t.result.tokens.total.toLocaleString() : "n/a";
     rows += `
     <tr class="task-row" data-task-id="${escapeHtml(t.task.id)}" data-index="${t.index}">
       <td>${t.index + 1}</td>
@@ -47717,11 +47791,12 @@ function renderTaskTable(tasks, config2, humanFeedback) {
       <td>${t.score.adherence.toFixed(1)}</td>
       <td>${t.score.outputQuality.toFixed(1)}</td>
       <td>${t.score.weightedScore.toFixed(2)}</td>
+      <td>${tokensCell}</td>
       <td>${escapeHtml(formatCategory(t.score.failureCategory))}</td>
       <td><span class="status ${statusClass}">${statusLabel}</span></td>
     </tr>
     <tr class="detail-row" data-task-id="${escapeHtml(t.task.id)}">
-      <td colspan="8">
+      <td colspan="9">
         ${renderTaskDetail(t, config2, humanFeedback)}
       </td>
     </tr>`;
@@ -47739,6 +47814,7 @@ function renderTaskTable(tasks, config2, humanFeedback) {
           <th class="sortable" data-col="adherence">Adherence</th>
           <th class="sortable" data-col="outputQuality">Output Quality</th>
           <th class="sortable" data-col="weightedScore">Weighted</th>
+          <th class="sortable" data-col="tokens">Tokens</th>
           <th class="sortable" data-col="failureCategory">Failure</th>
           <th>Status</th>
         </tr>
@@ -47812,19 +47888,21 @@ function renderTaskDetail(t, config2, humanFeedback) {
   <div class="detail-section">
     <h4>Agent Output</h4>
     <pre class="agent-output">${escapeHtml(truncatedOutput)}</pre>
-    <p class="metrics">Duration: ${(t.result.durationMs / 1e3).toFixed(1)}s | Turns: ${t.result.numTurns} | Cost: $${t.result.costUsd.toFixed(4)}</p>
+    <p class="metrics">Duration: ${(t.result.durationMs / 1e3).toFixed(1)}s | Turns: ${t.result.numTurns} | Cost: $${t.result.costUsd.toFixed(4)} | Tokens: ${t.result.tokens ? t.result.tokens.total.toLocaleString() : "n/a"}</p>
   </div>`;
   if (t.runDetails && t.runDetails.length > 1) {
     let runRows = "";
     for (let r = 0; r < t.runDetails.length; r++) {
       const rd = t.runDetails[r];
       const skills = rd.result.skillLoads.length > 0 ? rd.result.skillLoads.join(", ") : "none";
+      const runTokens = rd.result.tokens ? rd.result.tokens.total.toLocaleString() : "n/a";
       runRows += `<tr>
         <td>${r + 1}</td>
         <td>${rd.score.discovery}</td>
         <td>${rd.score.adherence}/5</td>
         <td>${rd.score.outputQuality}/5</td>
         <td>${rd.score.weightedScore.toFixed(2)}</td>
+        <td>${runTokens}</td>
         <td>${escapeHtml(skills)}</td>
       </tr>`;
     }
@@ -47832,7 +47910,7 @@ function renderTaskDetail(t, config2, humanFeedback) {
   <div class="detail-section">
     <h4>Per-Run Breakdown (${t.runDetails.length} runs)</h4>
     <table class="run-table">
-      <thead><tr><th>Run</th><th>Discovery</th><th>Adherence</th><th>Output</th><th>Weighted</th><th>Skills</th></tr></thead>
+      <thead><tr><th>Run</th><th>Discovery</th><th>Adherence</th><th>Output</th><th>Weighted</th><th>Tokens</th><th>Skills</th></tr></thead>
       <tbody>${runRows}</tbody>
     </table>
   </div>`;
@@ -47849,11 +47927,13 @@ function renderComparisonSection(comparison) {
   for (const t of tasks) {
     const w = t.withSkill.score;
     const b = t.withoutSkill.score;
+    const tokenCell = t.delta.totalTokensDelta !== void 0 ? `${t.withSkill.result.tokens.total.toLocaleString()} / ${t.withoutSkill.result.tokens.total.toLocaleString()} / <span class="delta">${escapeHtml(formatDelta(t.delta.totalTokensDelta, 0))}</span>` : "n/a";
     taskRows += `<tr>
       <td>${escapeHtml(t.taskId)}</td>
       <td>${w.adherence.toFixed(1)} / ${b.adherence.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.adherenceDelta, 1))}</span></td>
       <td>${w.outputQuality.toFixed(1)} / ${b.outputQuality.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.outputQualityDelta, 1))}</span></td>
       <td>${w.weightedScore.toFixed(2)} / ${b.weightedScore.toFixed(2)} / <span class="delta">${escapeHtml(formatDelta(t.delta.weightedScoreDelta))}</span></td>
+      <td data-sort="${t.delta.totalTokensDelta ?? 0}">${tokenCell}</td>
     </tr>`;
   }
   return `
@@ -47869,12 +47949,13 @@ function renderComparisonSection(comparison) {
       <tr><td>Weighted Score</td><td>${ws.avgWeightedScore.toFixed(2)}</td><td>${bs.avgWeightedScore.toFixed(2)}</td><td class="delta">${escapeHtml(formatDelta(d.avgWeightedScoreDelta))}</td></tr>
       <tr><td>Duration</td><td>${(ws.totalDurationMs / 1e3).toFixed(1)}s</td><td>${(bs.totalDurationMs / 1e3).toFixed(1)}s</td><td class="delta">${escapeHtml(formatDelta(d.totalDurationDeltaMs / 1e3, 1))}s</td></tr>
       <tr><td>Cost</td><td>$${ws.totalCostUsd.toFixed(4)}</td><td>$${bs.totalCostUsd.toFixed(4)}</td><td class="delta">$${escapeHtml(formatDelta(d.totalCostDeltaUsd, 4))}</td></tr>
+      <tr><td>Tokens</td><td>${ws.totalTokens !== void 0 ? ws.totalTokens.toLocaleString() : "n/a"}</td><td>${bs.totalTokens !== void 0 ? bs.totalTokens.toLocaleString() : "n/a"}</td><td class="delta">${d.totalTokensDelta !== void 0 ? escapeHtml(formatDelta(d.totalTokensDelta, 0)) : "n/a"}</td></tr>
     </tbody>
   </table>
   <h3>Per-Task Comparison</h3>
   <div class="table-wrap">
     <table>
-      <thead><tr><th>Task</th><th>Adherence (W / B / Delta)</th><th>Output (W / B / Delta)</th><th>Weighted (W / B / Delta)</th></tr></thead>
+      <thead><tr><th>Task</th><th>Adherence (W / B / Delta)</th><th>Output (W / B / Delta)</th><th>Weighted (W / B / Delta)</th><th>Tokens (W / B / Delta)</th></tr></thead>
       <tbody>${taskRows}</tbody>
     </table>
   </div>
@@ -48320,6 +48401,7 @@ function generateGitHubSummary(report, config2) {
   lines.push(`| Weighted Score | ${summary2.avgWeightedScore.toFixed(2)}${summary2.stddev ? ` \xB1 ${summary2.stddev.weightedScore.toFixed(2)}` : ""} | | |`);
   lines.push(`| Duration | ${(summary2.totalDurationMs / 1e3).toFixed(1)}s | | |`);
   lines.push(`| Cost | $${summary2.totalCostUsd.toFixed(4)} | | |`);
+  lines.push(`| Tokens | ${summary2.totalTokens !== void 0 ? summary2.totalTokens.toLocaleString() : "n/a"} | | |`);
   lines.push("");
   const failures = tasks.filter((t) => t.score.failureCategory !== "none");
   if (failures.length > 0) {
@@ -48415,6 +48497,11 @@ function generateGitHubSummary(report, config2) {
     lines.push(`| Adherence | ${ws.avgAdherence.toFixed(1)}/5 | ${bs.avgAdherence.toFixed(1)}/5 | **${formatDelta(d.avgAdherenceDelta)}** |`);
     lines.push(`| Output Quality | ${ws.avgOutputQuality.toFixed(1)}/5 | ${bs.avgOutputQuality.toFixed(1)}/5 | **${formatDelta(d.avgOutputQualityDelta)}** |`);
     lines.push(`| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | **${formatDelta(d.avgWeightedScoreDelta)}** |`);
+    if (d.totalTokensDelta !== void 0) {
+      const wsTokens = ws.totalTokens !== void 0 ? ws.totalTokens.toLocaleString() : "n/a";
+      const bsTokens = bs.totalTokens !== void 0 ? bs.totalTokens.toLocaleString() : "n/a";
+      lines.push(`| Tokens | ${wsTokens} | ${bsTokens} | **${formatDelta(d.totalTokensDelta, 0)}** |`);
+    }
     lines.push("");
   }
   if (report.blindComparison) {
@@ -48779,7 +48866,8 @@ function computeComparison(withPhase, basePhase, baselineLabel, evalTasks, compa
         outputQualityDelta: w.score.outputQuality - b.score.outputQuality,
         weightedScoreDelta: w.score.weightedScore - b.score.weightedScore,
         durationDeltaMs: w.result.durationMs - b.result.durationMs,
-        costDeltaUsd: w.result.costUsd - b.result.costUsd
+        costDeltaUsd: w.result.costUsd - b.result.costUsd,
+        totalTokensDelta: w.result.tokens && b.result.tokens ? w.result.tokens.total - b.result.tokens.total : void 0
       }
     });
   }
@@ -48792,7 +48880,8 @@ function computeComparison(withPhase, basePhase, baselineLabel, evalTasks, compa
       avgOutputQualityDelta: withPhase.summary.avgOutputQuality - basePhase.summary.avgOutputQuality,
       avgWeightedScoreDelta: withPhase.summary.avgWeightedScore - basePhase.summary.avgWeightedScore,
       totalDurationDeltaMs: withPhase.summary.totalDurationMs - basePhase.summary.totalDurationMs,
-      totalCostDeltaUsd: withPhase.summary.totalCostUsd - basePhase.summary.totalCostUsd
+      totalCostDeltaUsd: withPhase.summary.totalCostUsd - basePhase.summary.totalCostUsd,
+      totalTokensDelta: withPhase.summary.totalTokens !== void 0 && basePhase.summary.totalTokens !== void 0 ? withPhase.summary.totalTokens - basePhase.summary.totalTokens : void 0
     },
     baselineLabel
   };

--- a/action/dist/index.cjs
+++ b/action/dist/index.cjs
@@ -23162,12 +23162,14 @@ ${skillsPrompt}` : "You are a helpful AI assistant.";
           if (rawUsage) {
             const input = rawUsage.promptTokens ?? 0;
             const output2 = rawUsage.completionTokens ?? 0;
+            const cacheRead = 0;
+            const cacheCreation = 0;
             tokens = {
               input,
               output: output2,
-              cacheRead: 0,
-              cacheCreation: 0,
-              total: input + output2
+              cacheRead,
+              cacheCreation,
+              total: input + output2 + cacheRead + cacheCreation
             };
             totalForCost = input + output2;
           }
@@ -23364,12 +23366,14 @@ var init_openai_agents_runner = __esm({
           if (usage) {
             const input = usage.inputTokens ?? 0;
             const output2 = usage.outputTokens ?? 0;
+            const cacheRead = 0;
+            const cacheCreation = 0;
             tokens = {
               input,
               output: output2,
-              cacheRead: 0,
-              cacheCreation: 0,
-              total: input + output2
+              cacheRead,
+              cacheCreation,
+              total: input + output2 + cacheRead + cacheCreation
             };
             totalForCost = input + output2;
           }
@@ -47927,7 +47931,9 @@ function renderComparisonSection(comparison) {
   for (const t of tasks) {
     const w = t.withSkill.score;
     const b = t.withoutSkill.score;
-    const tokenCell = t.delta.totalTokensDelta !== void 0 ? `${t.withSkill.result.tokens.total.toLocaleString()} / ${t.withoutSkill.result.tokens.total.toLocaleString()} / <span class="delta">${escapeHtml(formatDelta(t.delta.totalTokensDelta, 0))}</span>` : "n/a";
+    const wTokens = t.withSkill.result.tokens;
+    const bTokens = t.withoutSkill.result.tokens;
+    const tokenCell = wTokens && bTokens && t.delta.totalTokensDelta !== void 0 ? `${wTokens.total.toLocaleString()} / ${bTokens.total.toLocaleString()} / <span class="delta">${escapeHtml(formatDelta(t.delta.totalTokensDelta, 0))}</span>` : "n/a";
     taskRows += `<tr>
       <td>${escapeHtml(t.taskId)}</td>
       <td>${w.adherence.toFixed(1)} / ${b.adherence.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.adherenceDelta, 1))}</span></td>
@@ -48288,6 +48294,12 @@ function renderScript() {
       else if (sortCol === 'taskId') { valA = dA.taskId.toLowerCase(); valB = dB.taskId.toLowerCase(); }
       else if (sortCol === 'failureCategory') { valA = dA.failureCategory; valB = dB.failureCategory; }
       else { valA = dA[sortCol]; valB = dB[sortCol]; }
+      // Always push null/undefined to the end, regardless of direction.
+      const aMissing = valA === null || valA === undefined;
+      const bMissing = valB === null || valB === undefined;
+      if (aMissing && bMissing) return 0;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
       if (valA < valB) return sortAsc ? -1 : 1;
       if (valA > valB) return sortAsc ? 1 : -1;
       return 0;

--- a/src/__tests__/aggregator.test.ts
+++ b/src/__tests__/aggregator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeStddev, aggregateScores, FLAKY_STDDEV_THRESHOLD, isFlaky } from '../scorer/aggregator.js';
+import { computeStddev, aggregateScores, aggregateResults, FLAKY_STDDEV_THRESHOLD, isFlaky } from '../scorer/aggregator.js';
 import { computeSummary } from '../report/report.js';
 import { makeScore, makeResult } from './fixtures/test-helpers.js';
 
@@ -170,5 +170,52 @@ describe('computeSummary', () => {
     const scores = [makeScore()]; // no stddev property
     const summary = computeSummary(results, scores, 2);
     expect(summary.stddev).toBeUndefined();
+  });
+
+  it('sums totalTokens across tasks when every result has tokens', () => {
+    const tokensA = { input: 100, output: 50, cacheRead: 0, cacheCreation: 0, total: 150 };
+    const tokensB = { input: 200, output: 75, cacheRead: 25, cacheCreation: 10, total: 310 };
+    const results = [
+      makeResult({ taskId: 't1', tokens: tokensA }),
+      makeResult({ taskId: 't2', tokens: tokensB }),
+    ];
+    const scores = [makeScore({ taskId: 't1' }), makeScore({ taskId: 't2' })];
+    const summary = computeSummary(results, scores, 1);
+    expect(summary.totalTokens).toBe(460);
+  });
+
+  it('leaves totalTokens undefined when any task lacks tokens', () => {
+    const results = [
+      makeResult({ taskId: 't1', tokens: { input: 10, output: 5, cacheRead: 0, cacheCreation: 0, total: 15 } }),
+      makeResult({ taskId: 't2' }), // no tokens
+    ];
+    const scores = [makeScore({ taskId: 't1' }), makeScore({ taskId: 't2' })];
+    const summary = computeSummary(results, scores, 1);
+    expect(summary.totalTokens).toBeUndefined();
+  });
+});
+
+describe('aggregateResults token sum', () => {
+  it('sums tokens across runs when every run reports them', () => {
+    const run1 = [makeResult({ taskId: 't1', tokens: { input: 100, output: 50, cacheRead: 10, cacheCreation: 5, total: 165 } })];
+    const run2 = [makeResult({ taskId: 't1', tokens: { input: 120, output: 60, cacheRead: 20, cacheCreation: 0, total: 200 } })];
+    const run3 = [makeResult({ taskId: 't1', tokens: { input: 80, output: 40, cacheRead: 0, cacheCreation: 0, total: 120 } })];
+    const scores = [[makeScore({ taskId: 't1' })], [makeScore({ taskId: 't1' })], [makeScore({ taskId: 't1' })]];
+    const result = aggregateResults([run1, run2, run3], scores);
+    expect(result[0].tokens).toEqual({
+      input: 300,
+      output: 150,
+      cacheRead: 30,
+      cacheCreation: 5,
+      total: 485,
+    });
+  });
+
+  it('leaves tokens undefined when any run lacks them', () => {
+    const run1 = [makeResult({ taskId: 't1', tokens: { input: 100, output: 50, cacheRead: 0, cacheCreation: 0, total: 150 } })];
+    const run2 = [makeResult({ taskId: 't1' })]; // no tokens
+    const scores = [[makeScore({ taskId: 't1' })], [makeScore({ taskId: 't1' })]];
+    const result = aggregateResults([run1, run2], scores);
+    expect(result[0].tokens).toBeUndefined();
   });
 });

--- a/src/__tests__/base-runner.test.ts
+++ b/src/__tests__/base-runner.test.ts
@@ -32,6 +32,10 @@ class TestableBaseRunner extends BaseRunner {
   async runTask(task: EvalTask, logger?: SessionLogger): Promise<TaskResult> {
     return this.mockRunTask(task, logger);
   }
+
+  buildResultForTest(task: EvalTask, fields: Parameters<BaseRunner['buildTaskResult']>[1]): TaskResult {
+    return this.buildTaskResult(task, fields);
+  }
 }
 
 function makeTask(overrides: Partial<EvalTask> = {}): EvalTask {
@@ -222,6 +226,34 @@ describe('BaseRunner fixture integration', () => {
 
     expect(mockRunFixtureScript).not.toHaveBeenCalled();
     expect(runner.mockRunTask).toHaveBeenCalled();
+  });
+
+  it('buildTaskResult threads tokens onto the TaskResult', () => {
+    const task = makeTask();
+    const tokens = { input: 1000, output: 250, cacheRead: 50, cacheCreation: 10, total: 1310 };
+    const result = runner.buildResultForTest(task, {
+      output: 'ok',
+      durationMs: 100,
+      numTurns: 1,
+      costUsd: 0.001,
+      skillLoads: [],
+      toolCalls: [],
+      tokens,
+    });
+    expect(result.tokens).toEqual(tokens);
+  });
+
+  it('buildTaskResult leaves tokens undefined when not provided', () => {
+    const task = makeTask();
+    const result = runner.buildResultForTest(task, {
+      output: 'ok',
+      durationMs: 100,
+      numTurns: 1,
+      costUsd: 0.001,
+      skillLoads: [],
+      toolCalls: [],
+    });
+    expect(result.tokens).toBeUndefined();
   });
 
   it('handles teardown throwing an unexpected error without masking the task result', async () => {

--- a/src/__tests__/copilot-sdk-runner.test.ts
+++ b/src/__tests__/copilot-sdk-runner.test.ts
@@ -109,6 +109,11 @@ describe('CopilotSdkRunner', () => {
     expect(result.costUsd).toBe(0);
   });
 
+  it('leaves tokens undefined (Copilot SDK does not expose usage)', async () => {
+    const result = await runner.runTask(mockTask);
+    expect(result.tokens).toBeUndefined();
+  });
+
   it('sends task prompt via sendAndWait', async () => {
     await runner.runTask(mockTask);
 

--- a/src/__tests__/github-summary.test.ts
+++ b/src/__tests__/github-summary.test.ts
@@ -208,6 +208,31 @@ describe('generateGitHubSummary', () => {
     expect(summary).toMatch(/Avg Output Quality.*3\.5/);
   });
 
+  it('renders Tokens row with thousand-separated value when summary reports totalTokens', () => {
+    const report = makeReport({
+      summary: {
+        totalTasks: 1,
+        numRuns: 1,
+        discoveryAccuracy: 1,
+        avgAdherence: 5,
+        avgOutputQuality: 5,
+        avgWeightedScore: 1,
+        totalDurationMs: 1000,
+        totalCostUsd: 0.01,
+        totalTokens: 123456,
+      },
+    });
+
+    const summary = generateGitHubSummary(report);
+    expect(summary).toMatch(/\| Tokens \| 123,456 \|/);
+  });
+
+  it('renders Tokens row as n/a when summary omits totalTokens', () => {
+    const report = makeReport();
+    const summary = generateGitHubSummary(report);
+    expect(summary).toMatch(/\| Tokens \| n\/a \|/);
+  });
+
   it('passes at exact threshold boundary (>=)', () => {
     const customConfig: EvalConfig = { ...DEFAULT_CONFIG, discoveryThreshold: 0.6, scoreThreshold: 3.0 };
     const report = makeReport({

--- a/src/__tests__/html-report.test.ts
+++ b/src/__tests__/html-report.test.ts
@@ -93,6 +93,22 @@ describe('generateHtmlReport', () => {
     expect(html).toContain('>2<');
   });
 
+  it('renders Tokens stat card with summed value when results report tokens', async () => {
+    const html = await generateHtmlReport(makeReportOptions({
+      results: [
+        makeResult({ taskId: 'task-1', skillLoads: ['my-skill'], tokens: { input: 1000, output: 500, cacheRead: 100, cacheCreation: 0, total: 1600 } }),
+        makeResult({ taskId: 'task-2', skillLoads: [], tokens: { input: 2000, output: 800, cacheRead: 0, cacheCreation: 100, total: 2900 } }),
+      ],
+    }));
+
+    expect(html).toMatch(/<div class="stat-value">4,500<\/div>\s*<div class="stat-label">Tokens<\/div>/);
+  });
+
+  it('renders Tokens stat card as em-dash when any result lacks tokens', async () => {
+    const html = await generateHtmlReport(makeReportOptions());
+    expect(html).toMatch(/<div class="stat-value">&mdash;<\/div>\s*<div class="stat-label">Tokens<\/div>/);
+  });
+
   it('renders the correct number of task rows', async () => {
     const html = await generateHtmlReport(makeReportOptions());
 

--- a/src/__tests__/response-cache.test.ts
+++ b/src/__tests__/response-cache.test.ts
@@ -341,6 +341,19 @@ describe('ResponseCache get/set', () => {
     expect(retrieved).toEqual(taskResult);
   });
 
+  it('round-trips tokens on a TaskResult', async () => {
+    const cache = makeCache();
+    const taskResult = makeTaskResult({
+      tokens: { input: 1234, output: 567, cacheRead: 89, cacheCreation: 12, total: 1902 },
+    });
+
+    await cache.set(hexKey1, taskResult, keyInputs);
+    const retrieved = await cache.get(hexKey1);
+
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.tokens).toEqual(taskResult.tokens);
+  });
+
   it('returns null for expired entries', async () => {
     const cache = makeCache({ ttlHours: 1 });
     const taskResult = makeTaskResult();

--- a/src/__tests__/vercel-ai-runner.test.ts
+++ b/src/__tests__/vercel-ai-runner.test.ts
@@ -51,7 +51,7 @@ function createMockAiModule(overrides: {
   } else {
     mockGenerateText = vi.fn().mockResolvedValue(overrides.generateTextResult ?? {
       text: 'Hello!',
-      usage: { promptTokens: 100, completionTokens: 50 },
+      usage: { inputTokens: 100, outputTokens: 50 },
     });
   }
 
@@ -151,7 +151,7 @@ describe('VercelAiRunner', () => {
           toolCallId: 'tc-1',
         }],
       });
-      return { text: 'Hello!', usage: { promptTokens: 100, completionTokens: 50 } };
+      return { text: 'Hello!', usage: { inputTokens: 100, outputTokens: 50 } };
     });
 
     const result = await runner.runTask(mockTask);
@@ -179,7 +179,7 @@ describe('VercelAiRunner', () => {
           toolCallId: 'tc-1',
         }],
       });
-      return { text: 'Hello!', usage: { promptTokens: 100, completionTokens: 50 } };
+      return { text: 'Hello!', usage: { inputTokens: 100, outputTokens: 50 } };
     });
 
     const result = await runner.runTask(mockTask);
@@ -194,7 +194,7 @@ describe('VercelAiRunner', () => {
           { toolName: 'bash', args: { command: 'echo hi' }, toolCallId: 'tc-2' },
         ],
       });
-      return { text: 'Hello!', usage: { promptTokens: 100, completionTokens: 50 } };
+      return { text: 'Hello!', usage: { inputTokens: 100, outputTokens: 50 } };
     });
 
     const result = await runner.runTask(mockTask);

--- a/src/__tests__/vercel-ai-runner.test.ts
+++ b/src/__tests__/vercel-ai-runner.test.ts
@@ -125,6 +125,23 @@ describe('VercelAiRunner', () => {
     expect(result.costUsd).toBeGreaterThan(0);
   });
 
+  it('populates tokens from generateText usage (cache fields default to 0)', async () => {
+    const result = await runner.runTask(mockTask);
+    expect(result.tokens).toEqual({
+      input: 100,
+      output: 50,
+      cacheRead: 0,
+      cacheCreation: 0,
+      total: 150,
+    });
+  });
+
+  it('leaves tokens undefined when generateText does not return usage', async () => {
+    mockAi.generateText.mockImplementation(async () => ({ text: 'Hello!' }));
+    const result = await runner.runTask(mockTask);
+    expect(result.tokens).toBeUndefined();
+  });
+
   it('does NOT detect skill via readFile when countReadAsFallback is false', async () => {
     mockAi.generateText.mockImplementation(async (opts: any) => {
       opts.onStepFinish?.({

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export type {
   FixtureConfig,
   ToolCallRecord,
   TaskResult,
+  TokenUsage,
   FailureCategory,
   ChecklistItemResult,
   JudgeScore,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -329,6 +329,10 @@ function computeComparison(
         weightedScoreDelta: w.score.weightedScore - b.score.weightedScore,
         durationDeltaMs: w.result.durationMs - b.result.durationMs,
         costDeltaUsd: w.result.costUsd - b.result.costUsd,
+        totalTokensDelta:
+          w.result.tokens && b.result.tokens
+            ? w.result.tokens.total - b.result.tokens.total
+            : undefined,
       },
     });
   }
@@ -343,6 +347,10 @@ function computeComparison(
       avgWeightedScoreDelta: withPhase.summary.avgWeightedScore - basePhase.summary.avgWeightedScore,
       totalDurationDeltaMs: withPhase.summary.totalDurationMs - basePhase.summary.totalDurationMs,
       totalCostDeltaUsd: withPhase.summary.totalCostUsd - basePhase.summary.totalCostUsd,
+      totalTokensDelta:
+        withPhase.summary.totalTokens !== undefined && basePhase.summary.totalTokens !== undefined
+          ? withPhase.summary.totalTokens - basePhase.summary.totalTokens
+          : undefined,
     },
     baselineLabel,
   };

--- a/src/report/github-summary.ts
+++ b/src/report/github-summary.ts
@@ -39,6 +39,7 @@ export function generateGitHubSummary(report: EvaluationReport, config?: EvalCon
   lines.push(`| Weighted Score | ${summary.avgWeightedScore.toFixed(2)}${summary.stddev ? ` \u00B1 ${summary.stddev.weightedScore.toFixed(2)}` : ''} | | |`);
   lines.push(`| Duration | ${(summary.totalDurationMs / 1000).toFixed(1)}s | | |`);
   lines.push(`| Cost | $${summary.totalCostUsd.toFixed(4)} | | |`);
+  lines.push(`| Tokens | ${summary.totalTokens !== undefined ? summary.totalTokens.toLocaleString() : 'n/a'} | | |`);
   lines.push('');
 
   // Failures
@@ -153,6 +154,11 @@ export function generateGitHubSummary(report: EvaluationReport, config?: EvalCon
     lines.push(`| Adherence | ${ws.avgAdherence.toFixed(1)}/5 | ${bs.avgAdherence.toFixed(1)}/5 | **${formatDelta(d.avgAdherenceDelta)}** |`);
     lines.push(`| Output Quality | ${ws.avgOutputQuality.toFixed(1)}/5 | ${bs.avgOutputQuality.toFixed(1)}/5 | **${formatDelta(d.avgOutputQualityDelta)}** |`);
     lines.push(`| Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | **${formatDelta(d.avgWeightedScoreDelta)}** |`);
+    if (d.totalTokensDelta !== undefined) {
+      const wsTokens = ws.totalTokens !== undefined ? ws.totalTokens.toLocaleString() : 'n/a';
+      const bsTokens = bs.totalTokens !== undefined ? bs.totalTokens.toLocaleString() : 'n/a';
+      lines.push(`| Tokens | ${wsTokens} | ${bsTokens} | **${formatDelta(d.totalTokensDelta, 0)}** |`);
+    }
     lines.push('');
   }
 

--- a/src/report/html-report.ts
+++ b/src/report/html-report.ts
@@ -437,7 +437,7 @@ function renderComparisonSection(comparison: ComparisonData): string {
       <td>${w.adherence.toFixed(1)} / ${b.adherence.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.adherenceDelta, 1))}</span></td>
       <td>${w.outputQuality.toFixed(1)} / ${b.outputQuality.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.outputQualityDelta, 1))}</span></td>
       <td>${w.weightedScore.toFixed(2)} / ${b.weightedScore.toFixed(2)} / <span class="delta">${escapeHtml(formatDelta(t.delta.weightedScoreDelta))}</span></td>
-      <td data-sort="${t.delta.totalTokensDelta ?? 0}">${tokenCell}</td>
+      <td>${tokenCell}</td>
     </tr>`;
   }
 

--- a/src/report/html-report.ts
+++ b/src/report/html-report.ts
@@ -78,6 +78,7 @@ export async function generateHtmlReport(options: ReportOptions): Promise<string
     weightedScore: t.score.weightedScore,
     failureCategory: t.score.failureCategory,
     isFlaky: isFlaky(t.score.stddev),
+    tokens: t.result.tokens?.total ?? null,
   }));
 
   // Check if any cross-iteration regression data exists
@@ -202,6 +203,10 @@ function renderDashboard(summary: EvaluationSummary, config: EvalConfig): string
       <div class="stat-value">$${summary.totalCostUsd.toFixed(4)}</div>
       <div class="stat-label">Cost</div>
     </div>
+    <div class="stat">
+      <div class="stat-value">${summary.totalTokens !== undefined ? summary.totalTokens.toLocaleString() : '&mdash;'}</div>
+      <div class="stat-label">Tokens</div>
+    </div>
   </div>
 </section>`;
 }
@@ -253,6 +258,7 @@ function renderTaskTable(tasks: HtmlTaskData[], config: EvalConfig, humanFeedbac
     const statusClass = isFailed ? 'status-fail' : (flaky ? 'status-flaky' : 'status-pass');
     const statusLabel = isFailed ? 'FAIL' : (flaky ? 'FLAKY' : 'PASS');
 
+    const tokensCell = t.result.tokens ? t.result.tokens.total.toLocaleString() : 'n/a';
     rows += `
     <tr class="task-row" data-task-id="${escapeHtml(t.task.id)}" data-index="${t.index}">
       <td>${t.index + 1}</td>
@@ -261,11 +267,12 @@ function renderTaskTable(tasks: HtmlTaskData[], config: EvalConfig, humanFeedbac
       <td>${t.score.adherence.toFixed(1)}</td>
       <td>${t.score.outputQuality.toFixed(1)}</td>
       <td>${t.score.weightedScore.toFixed(2)}</td>
+      <td>${tokensCell}</td>
       <td>${escapeHtml(formatCategory(t.score.failureCategory))}</td>
       <td><span class="status ${statusClass}">${statusLabel}</span></td>
     </tr>
     <tr class="detail-row" data-task-id="${escapeHtml(t.task.id)}">
-      <td colspan="8">
+      <td colspan="9">
         ${renderTaskDetail(t, config, humanFeedback)}
       </td>
     </tr>`;
@@ -284,6 +291,7 @@ function renderTaskTable(tasks: HtmlTaskData[], config: EvalConfig, humanFeedbac
           <th class="sortable" data-col="adherence">Adherence</th>
           <th class="sortable" data-col="outputQuality">Output Quality</th>
           <th class="sortable" data-col="weightedScore">Weighted</th>
+          <th class="sortable" data-col="tokens">Tokens</th>
           <th class="sortable" data-col="failureCategory">Failure</th>
           <th>Status</th>
         </tr>
@@ -375,7 +383,7 @@ function renderTaskDetail(t: HtmlTaskData, config: EvalConfig, humanFeedback: Hu
   <div class="detail-section">
     <h4>Agent Output</h4>
     <pre class="agent-output">${escapeHtml(truncatedOutput)}</pre>
-    <p class="metrics">Duration: ${(t.result.durationMs / 1000).toFixed(1)}s | Turns: ${t.result.numTurns} | Cost: $${t.result.costUsd.toFixed(4)}</p>
+    <p class="metrics">Duration: ${(t.result.durationMs / 1000).toFixed(1)}s | Turns: ${t.result.numTurns} | Cost: $${t.result.costUsd.toFixed(4)} | Tokens: ${t.result.tokens ? t.result.tokens.total.toLocaleString() : 'n/a'}</p>
   </div>`;
 
   // Per-run breakdown
@@ -384,12 +392,14 @@ function renderTaskDetail(t: HtmlTaskData, config: EvalConfig, humanFeedback: Hu
     for (let r = 0; r < t.runDetails.length; r++) {
       const rd = t.runDetails[r];
       const skills = rd.result.skillLoads.length > 0 ? rd.result.skillLoads.join(', ') : 'none';
+      const runTokens = rd.result.tokens ? rd.result.tokens.total.toLocaleString() : 'n/a';
       runRows += `<tr>
         <td>${r + 1}</td>
         <td>${rd.score.discovery}</td>
         <td>${rd.score.adherence}/5</td>
         <td>${rd.score.outputQuality}/5</td>
         <td>${rd.score.weightedScore.toFixed(2)}</td>
+        <td>${runTokens}</td>
         <td>${escapeHtml(skills)}</td>
       </tr>`;
     }
@@ -397,7 +407,7 @@ function renderTaskDetail(t: HtmlTaskData, config: EvalConfig, humanFeedback: Hu
   <div class="detail-section">
     <h4>Per-Run Breakdown (${t.runDetails.length} runs)</h4>
     <table class="run-table">
-      <thead><tr><th>Run</th><th>Discovery</th><th>Adherence</th><th>Output</th><th>Weighted</th><th>Skills</th></tr></thead>
+      <thead><tr><th>Run</th><th>Discovery</th><th>Adherence</th><th>Output</th><th>Weighted</th><th>Tokens</th><th>Skills</th></tr></thead>
       <tbody>${runRows}</tbody>
     </table>
   </div>`;
@@ -417,11 +427,15 @@ function renderComparisonSection(comparison: ComparisonData): string {
   for (const t of tasks) {
     const w = t.withSkill.score;
     const b = t.withoutSkill.score;
+    const tokenCell = t.delta.totalTokensDelta !== undefined
+      ? `${t.withSkill.result.tokens!.total.toLocaleString()} / ${t.withoutSkill.result.tokens!.total.toLocaleString()} / <span class="delta">${escapeHtml(formatDelta(t.delta.totalTokensDelta, 0))}</span>`
+      : 'n/a';
     taskRows += `<tr>
       <td>${escapeHtml(t.taskId)}</td>
       <td>${w.adherence.toFixed(1)} / ${b.adherence.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.adherenceDelta, 1))}</span></td>
       <td>${w.outputQuality.toFixed(1)} / ${b.outputQuality.toFixed(1)} / <span class="delta">${escapeHtml(formatDelta(t.delta.outputQualityDelta, 1))}</span></td>
       <td>${w.weightedScore.toFixed(2)} / ${b.weightedScore.toFixed(2)} / <span class="delta">${escapeHtml(formatDelta(t.delta.weightedScoreDelta))}</span></td>
+      <td data-sort="${t.delta.totalTokensDelta ?? 0}">${tokenCell}</td>
     </tr>`;
   }
 
@@ -438,12 +452,13 @@ function renderComparisonSection(comparison: ComparisonData): string {
       <tr><td>Weighted Score</td><td>${ws.avgWeightedScore.toFixed(2)}</td><td>${bs.avgWeightedScore.toFixed(2)}</td><td class="delta">${escapeHtml(formatDelta(d.avgWeightedScoreDelta))}</td></tr>
       <tr><td>Duration</td><td>${(ws.totalDurationMs / 1000).toFixed(1)}s</td><td>${(bs.totalDurationMs / 1000).toFixed(1)}s</td><td class="delta">${escapeHtml(formatDelta(d.totalDurationDeltaMs / 1000, 1))}s</td></tr>
       <tr><td>Cost</td><td>$${ws.totalCostUsd.toFixed(4)}</td><td>$${bs.totalCostUsd.toFixed(4)}</td><td class="delta">$${escapeHtml(formatDelta(d.totalCostDeltaUsd, 4))}</td></tr>
+      <tr><td>Tokens</td><td>${ws.totalTokens !== undefined ? ws.totalTokens.toLocaleString() : 'n/a'}</td><td>${bs.totalTokens !== undefined ? bs.totalTokens.toLocaleString() : 'n/a'}</td><td class="delta">${d.totalTokensDelta !== undefined ? escapeHtml(formatDelta(d.totalTokensDelta, 0)) : 'n/a'}</td></tr>
     </tbody>
   </table>
   <h3>Per-Task Comparison</h3>
   <div class="table-wrap">
     <table>
-      <thead><tr><th>Task</th><th>Adherence (W / B / Delta)</th><th>Output (W / B / Delta)</th><th>Weighted (W / B / Delta)</th></tr></thead>
+      <thead><tr><th>Task</th><th>Adherence (W / B / Delta)</th><th>Output (W / B / Delta)</th><th>Weighted (W / B / Delta)</th><th>Tokens (W / B / Delta)</th></tr></thead>
       <tbody>${taskRows}</tbody>
     </table>
   </div>

--- a/src/report/html-report.ts
+++ b/src/report/html-report.ts
@@ -427,8 +427,10 @@ function renderComparisonSection(comparison: ComparisonData): string {
   for (const t of tasks) {
     const w = t.withSkill.score;
     const b = t.withoutSkill.score;
-    const tokenCell = t.delta.totalTokensDelta !== undefined
-      ? `${t.withSkill.result.tokens!.total.toLocaleString()} / ${t.withoutSkill.result.tokens!.total.toLocaleString()} / <span class="delta">${escapeHtml(formatDelta(t.delta.totalTokensDelta, 0))}</span>`
+    const wTokens = t.withSkill.result.tokens;
+    const bTokens = t.withoutSkill.result.tokens;
+    const tokenCell = wTokens && bTokens && t.delta.totalTokensDelta !== undefined
+      ? `${wTokens.total.toLocaleString()} / ${bTokens.total.toLocaleString()} / <span class="delta">${escapeHtml(formatDelta(t.delta.totalTokensDelta, 0))}</span>`
       : 'n/a';
     taskRows += `<tr>
       <td>${escapeHtml(t.taskId)}</td>
@@ -807,6 +809,12 @@ function renderScript(): string {
       else if (sortCol === 'taskId') { valA = dA.taskId.toLowerCase(); valB = dB.taskId.toLowerCase(); }
       else if (sortCol === 'failureCategory') { valA = dA.failureCategory; valB = dB.failureCategory; }
       else { valA = dA[sortCol]; valB = dB[sortCol]; }
+      // Always push null/undefined to the end, regardless of direction.
+      const aMissing = valA === null || valA === undefined;
+      const bMissing = valB === null || valB === undefined;
+      if (aMissing && bMissing) return 0;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
       if (valA < valB) return sortAsc ? -1 : 1;
       if (valA > valB) return sortAsc ? 1 : -1;
       return 0;

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -90,6 +90,7 @@ ${metaSection}
 | **Avg Weighted Score** | ${summary.avgWeightedScore.toFixed(2)}${summary.stddev ? ` \u00B1 ${summary.stddev.weightedScore.toFixed(2)}` : ''} | | |
 | **Total Duration** | ${(summary.totalDurationMs / 1000).toFixed(1)}s | | |
 | **Total Cost** | $${summary.totalCostUsd.toFixed(4)} | | |
+| **Total Tokens** | ${summary.totalTokens !== undefined ? summary.totalTokens.toLocaleString() : 'n/a'} | | |
 
 ## Failure Analysis
 
@@ -207,7 +208,7 @@ ${result.output.slice(0, config.reportOutputTruncation) || '(no output)'}
 
 </details>
 
-**Metrics:** Duration: ${(result.durationMs / 1000).toFixed(1)}s | Turns: ${result.numTurns} | Cost: $${result.costUsd.toFixed(4)}
+**Metrics:** Duration: ${(result.durationMs / 1000).toFixed(1)}s | Turns: ${result.numTurns} | Cost: $${result.costUsd.toFixed(4)} | Tokens: ${result.tokens ? result.tokens.total.toLocaleString() : 'n/a'}
 `;
 
     // Per-run breakdown
@@ -216,13 +217,14 @@ ${result.output.slice(0, config.reportOutputTruncation) || '(no output)'}
 <details>
 <summary>Per-run breakdown (${runDetails[i].length} runs)</summary>
 
-| Run | Discovery | Adherence | Output | Weighted | Skills Loaded |
-|-----|-----------|-----------|--------|----------|---------------|
+| Run | Discovery | Adherence | Output | Weighted | Tokens | Skills Loaded |
+|-----|-----------|-----------|--------|----------|--------|---------------|
 `;
       for (let r = 0; r < runDetails[i].length; r++) {
         const rd = runDetails[i][r];
         const skills = rd.result.skillLoads.length > 0 ? rd.result.skillLoads.join(', ') : 'none';
-        report += `| ${r + 1} | ${rd.score.discovery} | ${rd.score.adherence}/5 | ${rd.score.outputQuality}/5 | ${rd.score.weightedScore.toFixed(2)} | ${skills} |\n`;
+        const runTokens = rd.result.tokens ? rd.result.tokens.total.toLocaleString() : 'n/a';
+        report += `| ${r + 1} | ${rd.score.discovery} | ${rd.score.adherence}/5 | ${rd.score.outputQuality}/5 | ${rd.score.weightedScore.toFixed(2)} | ${runTokens} | ${skills} |\n`;
       }
       report += `\n</details>\n`;
     }
@@ -370,6 +372,11 @@ export function computeSummary(
     ? scores.reduce((sum, s) => sum + s.weightedScore, 0) / totalTasks
     : 0;
 
+  const allHaveTokens = results.length > 0 && results.every((r) => r.tokens);
+  const totalTokens = allHaveTokens
+    ? results.reduce((sum, r) => sum + r.tokens!.total, 0)
+    : undefined;
+
   const summary: EvaluationSummary = {
     totalTasks,
     numRuns,
@@ -379,6 +386,7 @@ export function computeSummary(
     avgWeightedScore,
     totalDurationMs: results.reduce((sum, r) => sum + r.durationMs, 0),
     totalCostUsd: results.reduce((sum, r) => sum + r.costUsd, 0),
+    totalTokens,
   };
 
   // Compute summary-level stddev as the mean of per-task stddevs (cross-run variability).
@@ -445,6 +453,7 @@ function generateComparisonSection(comparison: ComparisonData): string {
 | Weighted Score | ${ws.avgWeightedScore.toFixed(2)} | ${bs.avgWeightedScore.toFixed(2)} | ${formatDelta(d.avgWeightedScoreDelta)} | ${qualityImpact(d.avgWeightedScoreDelta, WEIGHTED_SCORE_IMPACT_THRESHOLD)} |
 | Duration | ${(ws.totalDurationMs / 1000).toFixed(1)}s | ${(bs.totalDurationMs / 1000).toFixed(1)}s | ${formatDelta(d.totalDurationDeltaMs / 1000, 1)}s | ${durationImpact(d.totalDurationDeltaMs)} |
 | Cost | $${ws.totalCostUsd.toFixed(4)} | $${bs.totalCostUsd.toFixed(4)} | $${formatDelta(d.totalCostDeltaUsd, 4)} | ${costImpact(d.totalCostDeltaUsd)} |
+| Tokens | ${ws.totalTokens !== undefined ? ws.totalTokens.toLocaleString() : 'n/a'} | ${bs.totalTokens !== undefined ? bs.totalTokens.toLocaleString() : 'n/a'} | ${d.totalTokensDelta !== undefined ? formatDelta(d.totalTokensDelta, 0) : 'n/a'} | ${d.totalTokensDelta !== undefined ? tokenImpact(d.totalTokensDelta) : ''} |
 
 ### Per-Task Comparison
 
@@ -486,6 +495,14 @@ function durationImpact(deltaMs: number): string {
 function costImpact(delta: number): string {
   if (delta > COST_IMPACT_THRESHOLD_USD) return 'Higher';
   if (delta < -COST_IMPACT_THRESHOLD_USD) return 'Lower';
+  return 'Similar';
+}
+
+const TOKEN_IMPACT_THRESHOLD = 100;
+
+function tokenImpact(delta: number): string {
+  if (delta > TOKEN_IMPACT_THRESHOLD) return 'Higher';
+  if (delta < -TOKEN_IMPACT_THRESHOLD) return 'Lower';
   return 'Similar';
 }
 

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -498,7 +498,8 @@ function costImpact(delta: number): string {
   return 'Similar';
 }
 
-const TOKEN_IMPACT_THRESHOLD = 100;
+// 1000 tokens ≈ $0.003 at Sonnet input rates — coarse enough to ignore whitespace-level deltas.
+const TOKEN_IMPACT_THRESHOLD = 1000;
 
 function tokenImpact(delta: number): string {
   if (delta > TOKEN_IMPACT_THRESHOLD) return 'Higher';

--- a/src/runner/base-runner.ts
+++ b/src/runner/base-runner.ts
@@ -9,6 +9,7 @@ import type { AgentRunner, AgentRunnerOptions } from './agent-runner.js';
 import type {
   EvalTask,
   TaskResult,
+  TokenUsage,
   ToolCallRecord,
 } from '../types.js';
 import { loadConfigSync } from '../config.js';
@@ -79,6 +80,7 @@ export abstract class BaseRunner implements AgentRunner {
       costUsd: number;
       skillLoads: string[];
       toolCalls: ToolCallRecord[];
+      tokens?: TokenUsage;
     },
   ): TaskResult {
     return {
@@ -92,6 +94,7 @@ export abstract class BaseRunner implements AgentRunner {
       toolCalls: fields.toolCalls,
       isError: false,
       errorMessage: '',
+      tokens: fields.tokens,
     };
   }
 

--- a/src/runner/claude-sdk-runner.ts
+++ b/src/runner/claude-sdk-runner.ts
@@ -14,6 +14,7 @@ import type {
   EvalTask,
   ToolCallRecord,
   TaskResult,
+  TokenUsage,
 } from '../types.js';
 import {
   isAssistantMessage,
@@ -41,6 +42,7 @@ export class ClaudeSdkRunner extends BaseRunner {
       let resultDurationMs = 0;
       let resultNumTurns = 0;
       let resultCostUsd = 0;
+      let resultTokens: TokenUsage | undefined;
 
       const toolPolicy = createToolPolicy(
         this.options.allowedWriteDirs ?? [],
@@ -118,6 +120,21 @@ export class ClaudeSdkRunner extends BaseRunner {
           resultNumTurns = message.num_turns ?? 0;
           resultCostUsd = message.total_cost_usd ?? 0;
 
+          const u = message.usage;
+          if (u) {
+            const input = u.input_tokens ?? 0;
+            const output = u.output_tokens ?? 0;
+            const cacheRead = u.cache_read_input_tokens ?? 0;
+            const cacheCreation = u.cache_creation_input_tokens ?? 0;
+            resultTokens = {
+              input,
+              output,
+              cacheRead,
+              cacheCreation,
+              total: input + output + cacheRead + cacheCreation,
+            };
+          }
+
           if (message.result) {
             resultOutput = message.result;
           }
@@ -131,6 +148,7 @@ export class ClaudeSdkRunner extends BaseRunner {
         costUsd: resultCostUsd,
         skillLoads,
         toolCalls,
+        tokens: resultTokens,
       });
     } catch (error) {
       return this.handleRunError(task, error, startTime, logger);

--- a/src/runner/openai-agents-runner.ts
+++ b/src/runner/openai-agents-runner.ts
@@ -10,7 +10,7 @@
  * Requires: @openai/agents, openai
  */
 
-import type { EvalTask, ToolCallRecord, TaskResult } from '../types.js';
+import type { EvalTask, ToolCallRecord, TaskResult, TokenUsage } from '../types.js';
 import { BaseRunner } from './base-runner.js';
 import type { SessionLogger } from '../session/session-logger.js';
 import { discoverSkills, type SkillMetadata } from './skill-discovery.js';
@@ -244,11 +244,24 @@ export class OpenAiAgentsRunner extends BaseRunner {
       // 5. Detect skill loads
       const skillLoads = detectSkillLoadsFromShellCommands(shellCommands, localSkills);
 
-      // 6. Extract usage
+      // 6. Extract usage (cache tokens not surfaced by the OpenAI Agents SDK).
       const usage = (result as unknown as { usage?: { inputTokens?: number; outputTokens?: number } }).usage;
-      const totalTokens = (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0);
+      let tokens: TokenUsage | undefined;
+      let totalForCost = 0;
+      if (usage) {
+        const input = usage.inputTokens ?? 0;
+        const output = usage.outputTokens ?? 0;
+        tokens = {
+          input,
+          output,
+          cacheRead: 0,
+          cacheCreation: 0,
+          total: input + output,
+        };
+        totalForCost = input + output;
+      }
       // Rough cost estimate — actual pricing varies by model and provider
-      const costUsd = totalTokens * 0.000003;
+      const costUsd = totalForCost * 0.000003;
 
       return this.buildTaskResult(task, {
         output: typeof output === 'string' ? output : JSON.stringify(output),
@@ -257,6 +270,7 @@ export class OpenAiAgentsRunner extends BaseRunner {
         costUsd,
         skillLoads,
         toolCalls,
+        tokens,
       });
     } catch (error) {
       return this.handleRunError(task, error, startTime, logger);

--- a/src/runner/openai-agents-runner.ts
+++ b/src/runner/openai-agents-runner.ts
@@ -251,12 +251,14 @@ export class OpenAiAgentsRunner extends BaseRunner {
       if (usage) {
         const input = usage.inputTokens ?? 0;
         const output = usage.outputTokens ?? 0;
+        const cacheRead = 0;
+        const cacheCreation = 0;
         tokens = {
           input,
           output,
-          cacheRead: 0,
-          cacheCreation: 0,
-          total: input + output,
+          cacheRead,
+          cacheCreation,
+          total: input + output + cacheRead + cacheCreation,
         };
         totalForCost = input + output;
       }

--- a/src/runner/vercel-ai-runner.ts
+++ b/src/runner/vercel-ai-runner.ts
@@ -11,7 +11,7 @@
  *   "openrouter:deepseek/deepseek-v3.2"
  */
 
-import type { EvalTask, ToolCallRecord, TaskResult } from '../types.js';
+import type { EvalTask, ToolCallRecord, TaskResult, TokenUsage } from '../types.js';
 import { BaseRunner } from './base-runner.js';
 import type { SessionLogger } from '../session/session-logger.js';
 import { discoverSkills, stripFrontmatter, type SkillMetadata } from './skill-discovery.js';
@@ -272,11 +272,25 @@ export class VercelAiRunner extends BaseRunner {
       const output = result.text ?? '';
       logger?.addTextMessage(output);
 
-      // Extract usage info
-      const usage = result.usage ?? { promptTokens: 0, completionTokens: 0 };
-      const totalTokens = (usage.promptTokens ?? 0) + (usage.completionTokens ?? 0);
+      // Extract usage info (cumulative across the tool loop).
+      // Vercel AI normalizes usage across providers; cache tokens are not surfaced here.
+      const rawUsage = result.usage as { promptTokens?: number; completionTokens?: number } | undefined;
+      let tokens: TokenUsage | undefined;
+      let totalForCost = 0;
+      if (rawUsage) {
+        const input = rawUsage.promptTokens ?? 0;
+        const output = rawUsage.completionTokens ?? 0;
+        tokens = {
+          input,
+          output,
+          cacheRead: 0,
+          cacheCreation: 0,
+          total: input + output,
+        };
+        totalForCost = input + output;
+      }
       // Rough cost estimate — actual pricing varies by model and provider
-      const costUsd = totalTokens * 0.000003;
+      const costUsd = totalForCost * 0.000003;
 
       return this.buildTaskResult(task, {
         output,
@@ -285,6 +299,7 @@ export class VercelAiRunner extends BaseRunner {
         costUsd,
         skillLoads,
         toolCalls,
+        tokens,
       });
     } catch (error) {
       return this.handleRunError(task, error, startTime, logger);

--- a/src/runner/vercel-ai-runner.ts
+++ b/src/runner/vercel-ai-runner.ts
@@ -274,12 +274,12 @@ export class VercelAiRunner extends BaseRunner {
 
       // Extract usage info (cumulative across the tool loop).
       // Vercel AI normalizes usage across providers; cache tokens are not surfaced here.
-      const rawUsage = result.usage as { promptTokens?: number; completionTokens?: number } | undefined;
+      const rawUsage = result.usage as { inputTokens?: number; outputTokens?: number } | undefined;
       let tokens: TokenUsage | undefined;
       let totalForCost = 0;
       if (rawUsage) {
-        const input = rawUsage.promptTokens ?? 0;
-        const output = rawUsage.completionTokens ?? 0;
+        const input = rawUsage.inputTokens ?? 0;
+        const output = rawUsage.outputTokens ?? 0;
         const cacheRead = 0;
         const cacheCreation = 0;
         tokens = {

--- a/src/runner/vercel-ai-runner.ts
+++ b/src/runner/vercel-ai-runner.ts
@@ -280,12 +280,14 @@ export class VercelAiRunner extends BaseRunner {
       if (rawUsage) {
         const input = rawUsage.promptTokens ?? 0;
         const output = rawUsage.completionTokens ?? 0;
+        const cacheRead = 0;
+        const cacheCreation = 0;
         tokens = {
           input,
           output,
-          cacheRead: 0,
-          cacheCreation: 0,
-          total: input + output,
+          cacheRead,
+          cacheCreation,
+          total: input + output + cacheRead + cacheCreation,
         };
         totalForCost = input + output;
       }

--- a/src/scorer/aggregator.ts
+++ b/src/scorer/aggregator.ts
@@ -78,6 +78,17 @@ export function aggregateResults(
 
     const repIdx = findRepresentativeIndex(scores);
     const rep = runs[repIdx];
+    // Partial data is misleading — omit tokens if any run couldn't report them.
+    const allHaveTokens = runs.every((r) => r.tokens);
+    const tokens = allHaveTokens
+      ? {
+          input: runs.reduce((s, r) => s + r.tokens!.input, 0),
+          output: runs.reduce((s, r) => s + r.tokens!.output, 0),
+          cacheRead: runs.reduce((s, r) => s + r.tokens!.cacheRead, 0),
+          cacheCreation: runs.reduce((s, r) => s + r.tokens!.cacheCreation, 0),
+          total: runs.reduce((s, r) => s + r.tokens!.total, 0),
+        }
+      : undefined;
     aggregated.push({
       taskId: rep.taskId,
       prompt: rep.prompt,
@@ -89,6 +100,7 @@ export function aggregateResults(
       toolCalls: rep.toolCalls,
       isError: runs.some((r) => r.isError),
       errorMessage: runs.filter((r) => r.isError).map((r) => r.errorMessage).join('; '),
+      tokens,
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,14 @@ export interface ToolCallRecord {
   input?: unknown;
 }
 
+export interface TokenUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+  total: number;
+}
+
 export interface TaskResult {
   taskId: string;
   prompt: string;
@@ -74,6 +82,8 @@ export interface TaskResult {
   toolCalls: ToolCallRecord[];
   isError: boolean;
   errorMessage: string;
+  /** Undefined when the runner cannot report usage (e.g. Copilot SDK). */
+  tokens?: TokenUsage;
 }
 
 // ============================================
@@ -229,6 +239,8 @@ export interface EvaluationSummary {
   avgWeightedScore: number; // 0-1
   totalDurationMs: number;
   totalCostUsd: number;
+  /** Undefined when any task's runner couldn't report tokens. */
+  totalTokens?: number;
   stddev?: ScoreStddev; // Only populated when N >= 2
 }
 
@@ -282,6 +294,8 @@ export interface TaskComparisonDelta {
   weightedScoreDelta: number;
   durationDeltaMs: number;
   costDeltaUsd: number;
+  /** Undefined when either arm lacks tokens. */
+  totalTokensDelta?: number;
 }
 
 /** Per-task comparison data with both sides */
@@ -304,6 +318,8 @@ export interface ComparisonSummary {
     avgWeightedScoreDelta: number;
     totalDurationDeltaMs: number;
     totalCostDeltaUsd: number;
+    /** Undefined when either arm lacks tokens. */
+    totalTokensDelta?: number;
   };
   baselineLabel: string;
 }


### PR DESCRIPTION
## Summary
- Every runner that can report token usage (Claude SDK, Vercel AI, OpenAI Agents) now attaches `tokens: { input, output, cacheRead, cacheCreation, total }` to each `TaskResult`. Copilot SDK leaves it `undefined` — neither BYOK nor Copilot-token auth expose usage.
- Totals flow through the response cache, multi-run aggregation (sum, undefined if any run is missing), and skill-vs-baseline deltas. Markdown / HTML / GitHub Actions reports surface the numbers alongside duration and cost.
- HTML task table gains a sortable Tokens column; comparison section gains a Tokens delta column.

## Design decisions
- **Per-task total only.** Matches how `durationMs` / `costUsd` already land — no per-message breakdown.
- **`tokens?` is optional.** `undefined` signals "runner can't report", which is distinct from "zero tokens used". Zero-filling would conflate the two.
- **Cache tokens tracked separately.** Shape mirrors the existing `MetricsData.tokens` (`input`, `output`, `cacheRead`, `cacheCreation`, `total`) so Anthropic cache reads don't get double-counted into `input`. Vercel/OpenAI leave cache fields at `0` since those SDKs don't surface them.
- **Aggregation sums, doesn't average.** Mirrors `costUsd` in `aggregateResults`. If any run in an N-run task lacks tokens, the aggregate is `undefined` — partial data is misleading.
- **No cost estimate.** Pricing drifts and differs per provider; raw counts only. Existing rough `costUsd` is untouched.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 418 tests passing (14 new: aggregator sum + cache round-trip + runner populate/omit + report rendering)
- [x] `npm run bundle:action` — rebundled `action/dist/index.cjs`
- [ ] `npm run dev run <eval.yaml> --runner claude-sdk` — confirm markdown + HTML reports include Tokens row/card with realistic numbers (input ≫ output, cacheRead non-zero on multi-turn)
- [ ] Same with `--runner vercel-ai --model anthropic:claude-sonnet-4-6` — tokens present, cache fields `0`
- [ ] Same with `--runner copilot-sdk` — Tokens shows `n/a` / `—` without crashing
- [ ] `--runs 3` — per-task tokens summed; per-run breakdown column shows each run
- [ ] `--compare <baseline>` — Tokens delta row in summary + per-task column in HTML