### PR TITLE
Add Google ADK runner (Python subprocess bridge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ python/__pycache__/
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Ignore any folder named .inbox at any depth
+.inbox/

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,10 @@ dist
 # Evaluation results (generated at runtime)
 results/
 
+# Python venv for the google-adk runner
+python/.venv/
+python/__pycache__/
+
 # yarn v3
 .pnp.*
 .yarn/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,16 +45,17 @@ npm run start           # Run compiled CLI
 ## Architecture
 
 ```
-YAML tasks → Config → Runner (Claude SDK | Vercel AI | OpenAI Agents | Copilot SDK) → Scorer (deterministic + LLM judge) → Report
+YAML tasks → Config → Runner (Claude SDK | Vercel AI | OpenAI Agents | Copilot SDK | Google ADK) → Scorer (deterministic + LLM judge) → Report
 ```
 
 ## Runners
 
-Four runners selected via `--runner` flag:
+Five runners selected via `--runner` flag:
 - `claude-sdk` (default) — uses Claude Agent SDK, model aliases like `sonnet`, `haiku`
 - `vercel-ai` — uses Vercel AI SDK, model format `"provider:model"` (e.g., `anthropic:claude-sonnet-4-6`, `google:gemini-2.5-pro`, `openai:gpt-5.2`, `openrouter:deepseek/deepseek-v3.2`)
 - `openai-agents` — uses OpenAI Agents SDK, plain model names (e.g., `gpt-5.2`)
 - `copilot-sdk` — uses GitHub Copilot SDK, model names like `gpt-5`, `claude-sonnet-4-6`
+- `google-adk` — Python subprocess bridge to Google ADK. Spawns `python/adk_runner.py`. Model names like `gemini-2.5-flash`, `gemini-2.5-pro`. v1 leaves `toolCalls`/`skillLoads` empty — judge `discovery` rating is the activation signal.
 
 ## Scoring
 
@@ -93,6 +94,7 @@ Peer dependencies (install as needed for non-Claude runners):
 - `ai`, `zod`, `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`, `@openrouter/ai-sdk-provider` - Vercel AI SDK
 - `@openai/agents`, `openai` - OpenAI Agents SDK
 - `@github/copilot-sdk` - GitHub Copilot SDK
+- Python 3 + `pip install -r python/requirements.txt` (`google-adk`, `google-genai`) - Google ADK runner. Override interpreter with `PYTHON_BIN`.
 
 ## Environment
 
@@ -103,6 +105,7 @@ Requires API key for selected runner in environment or `.env` file:
 - Vercel AI (openrouter:): `OPENROUTER_API_KEY`
 - Copilot SDK (GitHub auth): `COPILOT_GITHUB_TOKEN` (must have Copilot permissions)
 - Copilot SDK (BYOK): Auto-detects `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` when no Copilot token
+- Google ADK: `GOOGLE_API_KEY`
 
 For Bedrock: set `CLAUDE_CODE_USE_BEDROCK=1` + AWS env vars.
 

--- a/evals/example-greeting/skills/greeting/SKILL.md
+++ b/evals/example-greeting/skills/greeting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: greeting
-description: Use when the user greets you, says hello, asks for a welcome, or introduces themselves. Examples: "hello", "welcome me", "I just joined the team", "greet me".
+description: 'Use when the user greets you, says hello, asks for a welcome, or introduces themselves. Examples: "hello", "welcome me", "I just joined the team", "greet me".'
 ---
 
 # Greeting Skill

--- a/python/adk_runner.py
+++ b/python/adk_runner.py
@@ -1,0 +1,114 @@
+"""Google ADK subprocess harness for skilljack-evals.
+
+Reads a task spec as JSON on stdin, runs an ADK Agent with the skills found
+under <cwd>/.claude/skills/, and prints a single JSON line to stdout with the
+final response. Errors go to stderr with a non-zero exit code.
+
+v1 returns only output / numTurns / durationMs. Tool-call capture and
+skill-load detection are deferred — see plan for follow-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+import sys
+import time
+import traceback
+
+
+async def run(task: dict) -> dict:
+    from google.adk.agents import Agent
+    from google.adk.runners import InMemoryRunner
+    from google.adk.skills import load_skill_from_dir
+    from google.adk.tools.skill_toolset import SkillToolset
+    from google.genai import types
+
+    cwd = pathlib.Path(task["cwd"])
+    prompt = task["prompt"]
+    model = task.get("model") or "gemini-2.5-flash"
+
+    skills_dir = cwd / ".claude" / "skills"
+    tools = []
+    if skills_dir.is_dir():
+        loaded = [
+            load_skill_from_dir(d)
+            for d in sorted(skills_dir.iterdir())
+            if d.is_dir() and (d / "SKILL.md").is_file()
+        ]
+        if loaded:
+            tools.append(SkillToolset(skills=loaded))
+
+    agent = Agent(
+        name="eval_agent",
+        model=model,
+        instruction="You are a helpful assistant. Use available skills when relevant.",
+        tools=tools,
+    )
+
+    app_name = "skilljack-evals"
+    user_id = "eval-user"
+    runner = InMemoryRunner(agent=agent, app_name=app_name)
+    session = await runner.session_service.create_session(
+        app_name=app_name, user_id=user_id
+    )
+    content = types.Content(
+        role="user", parts=[types.Part.from_text(text=prompt)]
+    )
+
+    text = ""
+    turns = 0
+    skill_loads: list[str] = []
+    started = time.monotonic()
+    async for event in runner.run_async(
+        user_id=user_id, session_id=session.id, new_message=content
+    ):
+        if event.author == "user" or not event.content:
+            continue
+        turns += 1
+        for part in event.content.parts or []:
+            if getattr(part, "text", None):
+                text += part.text
+        # SkillToolset surfaces 'load_skill(skill_name=...)' when the agent
+        # activates a skill — that's the canonical activation signal.
+        for fc in event.get_function_calls() or []:
+            if fc.name == "load_skill":
+                args = dict(fc.args) if fc.args else {}
+                name = args.get("skill_name") or args.get("name")
+                if isinstance(name, str) and name not in skill_loads:
+                    skill_loads.append(name)
+
+    return {
+        "output": text,
+        "numTurns": turns,
+        "skillLoads": skill_loads,
+        "durationMs": int((time.monotonic() - started) * 1000),
+    }
+
+
+async def main() -> int:
+    raw = sys.stdin.buffer.read().decode("utf-8")
+    if not raw.strip():
+        print("adk_runner: empty stdin", file=sys.stderr)
+        return 2
+    try:
+        task = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"adk_runner: invalid stdin JSON: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        result = await run(task)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        print(f"adk_runner: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+    sys.stdout.write(json.dumps(result, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,2 @@
+google-adk
+google-genai>=1.72.0,<2.0.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,7 @@ program
   .command('run')
   .description('Run the full evaluation pipeline: execute tasks → score → report')
   .argument('<tasks>', 'Path to tasks YAML file')
-  .option('--runner <type>', 'Runner type: claude-sdk, vercel-ai, openai-agents, copilot-sdk (default: claude-sdk)')
+  .option('--runner <type>', 'Runner type: claude-sdk, vercel-ai, openai-agents, copilot-sdk, google-adk (default: claude-sdk)')
   .option('--model <model>', 'Agent model (default: sonnet)')
   .option('--judge-model <model>', 'Judge model (default: haiku)')
   .option('--config <path>', 'Path to eval.config.yaml')

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,9 +17,9 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { DEFAULT_RUNNER_CONCURRENCY } from './utils/concurrency.js';
 
-export type RunnerType = 'claude-sdk' | 'vercel-ai' | 'openai-agents' | 'copilot-sdk';
+export type RunnerType = 'claude-sdk' | 'vercel-ai' | 'openai-agents' | 'copilot-sdk' | 'google-adk';
 
-export const VALID_RUNNER_TYPES: RunnerType[] = ['claude-sdk', 'vercel-ai', 'openai-agents', 'copilot-sdk'];
+export const VALID_RUNNER_TYPES: RunnerType[] = ['claude-sdk', 'vercel-ai', 'openai-agents', 'copilot-sdk', 'google-adk'];
 
 export interface EvalConfig {
   // Runner

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -290,7 +290,11 @@ async function setupSkills(
   cwd: string,
 ): Promise<boolean> {
   if (!skillsDir) return false;
-  if (config.runnerType === 'claude-sdk' || config.runnerType === 'copilot-sdk') {
+  if (
+    config.runnerType === 'claude-sdk' ||
+    config.runnerType === 'copilot-sdk' ||
+    config.runnerType === 'google-adk'
+  ) {
     console.log(`Setting up local skills from: ${skillsDir}`);
     const skillNames = await setupLocalSkills(skillsDir, cwd);
     console.log(`Skills configured: ${skillNames.join(', ')}`);

--- a/src/runner/google-adk-runner.ts
+++ b/src/runner/google-adk-runner.ts
@@ -1,0 +1,152 @@
+/**
+ * Google ADK Runner (subprocess bridge)
+ *
+ * Wraps the Python google-adk SDK by spawning python/adk_runner.py as a
+ * subprocess. Task spec is sent on stdin as JSON; the script returns a single
+ * JSON line on stdout with the final response.
+ *
+ * v1: returns output, numTurns, durationMs only. toolCalls and skillLoads
+ * are empty — see plan for follow-up work to wire those through.
+ *
+ * Requires Python 3 + `pip install -r python/requirements.txt` + GOOGLE_API_KEY.
+ */
+
+import type { EvalTask, TaskResult } from '../types.js';
+import { BaseRunner } from './base-runner.js';
+import type { SessionLogger } from '../session/session-logger.js';
+
+import { spawn } from 'child_process';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+interface AdkResult {
+  output: string;
+  numTurns: number;
+  durationMs: number;
+  skillLoads: string[];
+}
+
+function resolveScriptPath(): string {
+  // dist/runner/google-adk-runner.js → repo root → python/adk_runner.py
+  // (Same relative depth in src/, so dev mode via tsx works too.)
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, '..', '..', 'python', 'adk_runner.py');
+}
+
+function resolvePythonBin(): string {
+  const override = process.env.PYTHON_BIN;
+  if (override && override.trim()) return override.trim();
+  return process.platform === 'win32' ? 'python' : 'python3';
+}
+
+function parseAdkResult(stdout: string): AdkResult {
+  const lines = stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  if (lines.length === 0) {
+    throw new Error('ADK subprocess produced no output');
+  }
+  const last = lines[lines.length - 1];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(last);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`ADK subprocess output was not JSON: ${detail}\nLast line: ${last}`);
+  }
+  const obj = parsed as Partial<AdkResult>;
+  if (typeof obj.output !== 'string' || typeof obj.numTurns !== 'number' || typeof obj.durationMs !== 'number') {
+    throw new Error(`ADK subprocess returned malformed result: ${last}`);
+  }
+  return {
+    output: obj.output,
+    numTurns: obj.numTurns,
+    durationMs: obj.durationMs,
+    skillLoads: Array.isArray(obj.skillLoads) ? obj.skillLoads.filter((s): s is string => typeof s === 'string') : [],
+  };
+}
+
+export class GoogleAdkRunner extends BaseRunner {
+  readonly providerName = 'google-adk';
+
+  async runTask(task: EvalTask, logger?: SessionLogger): Promise<TaskResult> {
+    const startTime = Date.now();
+    const cwd = this.options.cwd ?? process.cwd();
+    const model = this.options.model ?? 'gemini-2.5-flash';
+    const scriptPath = resolveScriptPath();
+    const pythonBin = resolvePythonBin();
+
+    try {
+      const result = await this.spawnPython(pythonBin, scriptPath, cwd, {
+        taskId: task.id,
+        prompt: task.prompt,
+        model,
+        cwd,
+      });
+
+      logger?.addTextMessage(result.output);
+
+      return this.buildTaskResult(task, {
+        output: result.output,
+        durationMs: result.durationMs || (Date.now() - startTime),
+        numTurns: result.numTurns,
+        costUsd: 0,
+        skillLoads: result.skillLoads,
+        toolCalls: [],
+      });
+    } catch (error) {
+      return this.handleRunError(task, error, startTime, logger);
+    }
+  }
+
+  protected spawnPython(
+    pythonBin: string,
+    scriptPath: string,
+    cwd: string,
+    payload: Record<string, unknown>,
+  ): Promise<AdkResult> {
+    // google-genai expects GOOGLE_API_KEY; users with Vercel-AI .env may have
+    // GOOGLE_GENERATIVE_AI_API_KEY or GEMINI_API_KEY instead. Alias any of them.
+    const env = { ...process.env };
+    if (!env.GOOGLE_API_KEY) {
+      env.GOOGLE_API_KEY = env.GEMINI_API_KEY ?? env.GOOGLE_GENERATIVE_AI_API_KEY;
+    }
+
+    return new Promise<AdkResult>((resolve, reject) => {
+      const child = spawn(pythonBin, [scriptPath], {
+        cwd,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.setEncoding('utf-8');
+      child.stderr.setEncoding('utf-8');
+      child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+      child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+
+      child.on('error', (err) => {
+        const hint = err && (err as NodeJS.ErrnoException).code === 'ENOENT'
+          ? ` (is "${pythonBin}" on PATH? Set PYTHON_BIN to override.)`
+          : '';
+        reject(new Error(`Failed to spawn ADK subprocess: ${err.message}${hint}`));
+      });
+
+      child.on('close', (code) => {
+        if (code !== 0) {
+          const tail = stderr.trim().split(/\r?\n/).slice(-10).join('\n');
+          reject(new Error(`ADK subprocess exited ${code}\n${tail || '(no stderr)'}`));
+          return;
+        }
+        try {
+          resolve(parseAdkResult(stdout));
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      child.stdin.write(JSON.stringify(payload));
+      child.stdin.end();
+    });
+  }
+}

--- a/src/runner/runner-factory.ts
+++ b/src/runner/runner-factory.ts
@@ -57,6 +57,11 @@ export async function createRunner(
       return new CopilotSdkRunner(options, config);
     }
 
+    case 'google-adk': {
+      const { GoogleAdkRunner } = await import('./google-adk-runner.js');
+      return new GoogleAdkRunner(options, config);
+    }
+
     default:
       throw new Error(`Unknown runner type: ${type}`);
   }


### PR DESCRIPTION
## Summary

Adds a fifth runner, `google-adk`, bridging the TypeScript harness to Google's Python-only Agent Development Kit by spawning `python/adk_runner.py` per task. Skills are loaded via ADK's `SkillToolset`, and skill activations are detected from `load_skill` function calls.

## Changes

- New `src/runner/google-adk-runner.ts` + `python/adk_runner.py` subprocess bridge (`python/requirements.txt` for deps)
- Wired into `runner-factory.ts`, `pipeline.ts`, `config.ts`, and `cli.ts`
- `setupLocalSkills` runs for `google-adk` so skills land in `.claude/skills/`
- Aliases `GOOGLE_GENERATIVE_AI_API_KEY` / `GEMINI_API_KEY` -> `GOOGLE_API_KEY` on spawn so existing `.env` files keep working
- Quote the description in the example greeting `SKILL.md` (ADK's YAML parser rejects the unquoted colon-space)

## Notes

- Branch is currently ~6 commits behind `main`; may want a rebase/merge before landing.
- Requires a local Python environment with the ADK deps installed (`python/requirements.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)