### PR TITLE
Fix write-restriction under SDK 0.3.x and ADK script path

### DIFF
--- a/action/dist/index.cjs
+++ b/action/dist/index.cjs
@@ -22066,20 +22066,35 @@ function isWriteAllowed(resolvedPath, allowedWriteDirs, cwd) {
     return true;
   return isPathInDirs(resolvedPath, resolveWriteDirs(allowedWriteDirs, cwd));
 }
-function createToolPolicy(allowedWriteDirs, cwd) {
+function createPreToolUseHook(allowedWriteDirs, cwd) {
   const resolvedDirs = resolveWriteDirs(allowedWriteDirs, cwd);
-  return async (toolName, input, _options) => {
-    if (!["Write", "Edit"].includes(toolName)) {
-      return { behavior: "allow", updatedInput: input };
+  return async (input) => {
+    if (input.hook_event_name !== "PreToolUse")
+      return {};
+    if (!["Write", "Edit"].includes(input.tool_name)) {
+      return {
+        hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow" }
+      };
     }
-    const filePath = input.file_path || "";
+    if (allowedWriteDirs.length === 0) {
+      return {
+        hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow" }
+      };
+    }
+    const toolInput = input.tool_input ?? {};
+    const filePath = toolInput.file_path || "";
     const resolvedPath = path2.resolve(cwd, filePath);
     if (isPathInDirs(resolvedPath, resolvedDirs)) {
-      return { behavior: "allow", updatedInput: input };
+      return {
+        hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow" }
+      };
     }
     return {
-      behavior: "deny",
-      message: `Write denied: ${filePath} is outside allowed directories: ${allowedWriteDirs.join(", ")}`
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: `Write denied: ${filePath} is outside allowed directories: ${allowedWriteDirs.join(", ")}`
+      }
     };
   };
 }
@@ -23222,7 +23237,11 @@ __export(google_adk_runner_exports, {
 });
 function resolveScriptPath() {
   const here = path8.dirname((0, import_url2.fileURLToPath)(import_meta2.url));
-  return path8.resolve(here, "..", "..", "python", "adk_runner.py");
+  const candidates = [
+    path8.resolve(here, "..", "..", "python", "adk_runner.py"),
+    path8.resolve(here, "..", "..", "..", "python", "adk_runner.py")
+  ];
+  return candidates.find((p) => (0, import_fs6.existsSync)(p)) ?? candidates[0];
 }
 function resolvePythonBin() {
   const override = process.env.PYTHON_BIN;
@@ -23255,12 +23274,13 @@ Last line: ${last}`);
     skillLoads: Array.isArray(obj.skillLoads) ? obj.skillLoads.filter((s) => typeof s === "string") : []
   };
 }
-var import_child_process7, path8, import_url2, import_meta2, GoogleAdkRunner;
+var import_child_process7, import_fs6, path8, import_url2, import_meta2, GoogleAdkRunner;
 var init_google_adk_runner = __esm({
   "dist/src/runner/google-adk-runner.js"() {
     "use strict";
     init_base_runner();
     import_child_process7 = require("child_process");
+    import_fs6 = require("fs");
     path8 = __toESM(require("path"), 1);
     import_url2 = require("url");
     import_meta2 = {};
@@ -43280,7 +43300,7 @@ var ClaudeSdkRunner = class extends BaseRunner {
       let resultNumTurns = 0;
       let resultCostUsd = 0;
       let resultTokens;
-      const toolPolicy = createToolPolicy(this.options.allowedWriteDirs ?? [], this.options.cwd ?? process.cwd());
+      const preToolUseHook = createPreToolUseHook(this.options.allowedWriteDirs ?? [], this.options.cwd ?? process.cwd());
       const q = kze({
         prompt: task.prompt,
         options: {
@@ -43298,8 +43318,13 @@ var ClaudeSdkRunner = class extends BaseRunner {
             "Skill",
             "Task"
           ],
-          permissionMode: "bypassPermissions",
-          canUseTool: toolPolicy
+          // 'dontAsk' keeps execution headless (no prompts) while still
+          // consulting the PreToolUse hook per call. 'bypassPermissions' would
+          // shadow the hook/canUseTool and disable the write restriction.
+          permissionMode: "dontAsk",
+          hooks: {
+            PreToolUse: [{ hooks: [preToolUseHook] }]
+          }
         }
       });
       for await (const message of q) {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   },
   "files": [
     "dist",
-    "action"
+    "action",
+    "python"
   ]
 }

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import * as path from 'path';
-import { isWriteAllowed } from '../runner/security.js';
+import { isWriteAllowed, createPreToolUseHook } from '../runner/security.js';
 
 describe('isWriteAllowed', () => {
   const cwd = '/app';
@@ -42,5 +42,69 @@ describe('isWriteAllowed', () => {
     expect(isWriteAllowed(resultsFile, allowed, cwd)).toBe(true);
     expect(isWriteAllowed(fixturesFile, allowed, cwd)).toBe(true);
     expect(isWriteAllowed(otherFile, allowed, cwd)).toBe(false);
+  });
+});
+
+describe('createPreToolUseHook', () => {
+  const cwd = '/app';
+  const signal = new AbortController().signal;
+
+  // Build a minimal PreToolUse hook input; the hook only reads
+  // hook_event_name / tool_name / tool_input.
+  function input(toolName: string, filePath?: string) {
+    return {
+      hook_event_name: 'PreToolUse',
+      tool_name: toolName,
+      tool_input: filePath === undefined ? {} : { file_path: filePath },
+      tool_use_id: 'tu_1',
+    } as never;
+  }
+
+  async function decide(
+    hook: ReturnType<typeof createPreToolUseHook>,
+    toolName: string,
+    filePath?: string,
+  ): Promise<string | undefined> {
+    const out = (await hook(input(toolName, filePath), 'tu_1', { signal })) as {
+      hookSpecificOutput?: { permissionDecision?: string };
+    };
+    return out.hookSpecificOutput?.permissionDecision;
+  }
+
+  it('allows non-write tools regardless of path', async () => {
+    const hook = createPreToolUseHook(['./results/'], cwd);
+    expect(await decide(hook, 'Bash')).toBe('allow');
+    expect(await decide(hook, 'Read', path.resolve(cwd, 'src/secret.ts'))).toBe('allow');
+  });
+
+  it('allows Write inside an allowed directory', async () => {
+    const hook = createPreToolUseHook(['./results/'], cwd);
+    expect(await decide(hook, 'Write', path.resolve(cwd, 'results/out.json'))).toBe('allow');
+  });
+
+  it('denies Write outside allowed directories', async () => {
+    const hook = createPreToolUseHook(['./results/'], cwd);
+    expect(await decide(hook, 'Write', path.resolve(cwd, 'src/evil.ts'))).toBe('deny');
+  });
+
+  it('denies Edit outside allowed directories', async () => {
+    const hook = createPreToolUseHook(['./results/'], cwd);
+    expect(await decide(hook, 'Edit', path.resolve(cwd, 'package.json'))).toBe('deny');
+  });
+
+  it('prevents prefix attack (results-evil should not match results)', async () => {
+    const hook = createPreToolUseHook(['./results/'], cwd);
+    expect(await decide(hook, 'Write', path.resolve(cwd, 'results-evil/hack.txt'))).toBe('deny');
+  });
+
+  it('allows all writes when allowedWriteDirs is empty', async () => {
+    const hook = createPreToolUseHook([], cwd);
+    expect(await decide(hook, 'Write', '/anywhere/file.txt')).toBe('allow');
+  });
+
+  it('ignores non-PreToolUse events', async () => {
+    const hook = createPreToolUseHook(['./results/'], cwd);
+    const out = await hook({ hook_event_name: 'PostToolUse' } as never, 'tu_1', { signal });
+    expect(out).toEqual({});
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export { CopilotSdkRunner } from './runner/copilot-sdk-runner.js';
 export type { AgentRunner, AgentRunnerOptions } from './runner/agent-runner.js';
 export { createRunner } from './runner/runner-factory.js';
 export { setupLocalSkills, cleanupLocalSkills } from './runner/skill-setup.js';
-export { createToolPolicy } from './runner/security.js';
+export { createToolPolicy, createPreToolUseHook } from './runner/security.js';
 
 // Scorer
 export { scoreTask, scoreAll } from './scorer/scorer.js';

--- a/src/runner/claude-sdk-runner.ts
+++ b/src/runner/claude-sdk-runner.ts
@@ -22,7 +22,7 @@ import {
   isTextBlock,
   isToolUseBlock,
 } from '../types.js';
-import { createToolPolicy } from './security.js';
+import { createPreToolUseHook } from './security.js';
 import { BaseRunner, buildTokenUsage } from './base-runner.js';
 import type { SessionLogger } from '../session/session-logger.js';
 
@@ -44,7 +44,7 @@ export class ClaudeSdkRunner extends BaseRunner {
       let resultCostUsd = 0;
       let resultTokens: TokenUsage | undefined;
 
-      const toolPolicy = createToolPolicy(
+      const preToolUseHook = createPreToolUseHook(
         this.options.allowedWriteDirs ?? [],
         this.options.cwd ?? process.cwd(),
       );
@@ -61,8 +61,13 @@ export class ClaudeSdkRunner extends BaseRunner {
             'Glob', 'Grep', 'Bash',
             'Skill', 'Task',
           ],
-          permissionMode: 'bypassPermissions',
-          canUseTool: toolPolicy,
+          // 'dontAsk' keeps execution headless (no prompts) while still
+          // consulting the PreToolUse hook per call. 'bypassPermissions' would
+          // shadow the hook/canUseTool and disable the write restriction.
+          permissionMode: 'dontAsk',
+          hooks: {
+            PreToolUse: [{ hooks: [preToolUseHook] }],
+          },
         },
       });
 

--- a/src/runner/google-adk-runner.ts
+++ b/src/runner/google-adk-runner.ts
@@ -16,6 +16,7 @@ import { BaseRunner } from './base-runner.js';
 import type { SessionLogger } from '../session/session-logger.js';
 
 import { spawn } from 'child_process';
+import { existsSync } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -27,10 +28,17 @@ interface AdkResult {
 }
 
 function resolveScriptPath(): string {
-  // dist/runner/google-adk-runner.js → repo root → python/adk_runner.py
-  // (Same relative depth in src/, so dev mode via tsx works too.)
+  // python/adk_runner.py lives at the repo root and is NOT compiled into dist.
+  // The distance from this module to the repo root differs between layouts:
+  //   dev  (tsx):  src/runner/google-adk-runner.ts      → ../../python
+  //   built (tsc): dist/src/runner/google-adk-runner.js  → ../../../python
+  // Probe the candidates and return the first that exists.
   const here = path.dirname(fileURLToPath(import.meta.url));
-  return path.resolve(here, '..', '..', 'python', 'adk_runner.py');
+  const candidates = [
+    path.resolve(here, '..', '..', 'python', 'adk_runner.py'),
+    path.resolve(here, '..', '..', '..', 'python', 'adk_runner.py'),
+  ];
+  return candidates.find((p) => existsSync(p)) ?? candidates[0];
 }
 
 function resolvePythonBin(): string {

--- a/src/runner/security.ts
+++ b/src/runner/security.ts
@@ -1,11 +1,17 @@
 /**
  * Security policies for the evaluation runner.
  *
- * Restricts file writes to allowed directories. Provides both:
- * - createToolPolicy(): Agent SDK canUseTool callback (Claude SDK runner)
+ * Restricts file writes to allowed directories. Provides:
+ * - createPreToolUseHook(): Agent SDK PreToolUse hook (Claude SDK runner). This
+ *   is the enforcement path: under permissionMode 'dontAsk' the hook is consulted
+ *   for every tool call while staying fully headless.
+ * - createToolPolicy(): Legacy canUseTool callback. NOTE: as of claude-agent-sdk
+ *   0.3.x, canUseTool is NOT invoked when permissionMode is 'bypassPermissions'
+ *   (it is shadowed by the pre-approval). Kept for API compatibility only.
  * - isWriteAllowed(): Standalone path check (Vercel AI / OpenAI runners)
  */
 
+import type { HookCallback } from '@anthropic-ai/claude-agent-sdk';
 import * as path from 'path';
 
 /**
@@ -46,10 +52,68 @@ export function isWriteAllowed(
 }
 
 /**
+ * Create a PreToolUse hook that restricts Write/Edit to allowed directories.
+ *
+ * Use with `permissionMode: 'dontAsk'`: pre-approved tools (via `allowedTools`)
+ * are auto-allowed, this hook is still consulted per call, and nothing ever
+ * produces an interactive prompt — so it works headlessly in CI. Returns 'deny'
+ * for Write/Edit targeting a path outside the allowed directories.
+ *
+ * Replaces createToolPolicy() (canUseTool), which the SDK no longer invokes
+ * under 'bypassPermissions'.
+ */
+export function createPreToolUseHook(
+  allowedWriteDirs: string[],
+  cwd: string,
+): HookCallback {
+  const resolvedDirs = resolveWriteDirs(allowedWriteDirs, cwd);
+
+  return async (input) => {
+    if (input.hook_event_name !== 'PreToolUse') return {};
+
+    // Allow all non-write tools (Read, Glob, Grep, Bash, Skill, Task, ...)
+    if (!['Write', 'Edit'].includes(input.tool_name)) {
+      return {
+        hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' },
+      };
+    }
+
+    // No restrictions configured — allow all writes (matches isWriteAllowed).
+    if (allowedWriteDirs.length === 0) {
+      return {
+        hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' },
+      };
+    }
+
+    const toolInput = (input.tool_input ?? {}) as Record<string, unknown>;
+    const filePath = (toolInput.file_path as string) || '';
+    const resolvedPath = path.resolve(cwd, filePath);
+
+    if (isPathInDirs(resolvedPath, resolvedDirs)) {
+      return {
+        hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' },
+      };
+    }
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: `Write denied: ${filePath} is outside allowed directories: ${allowedWriteDirs.join(', ')}`,
+      },
+    };
+  };
+}
+
+/**
  * Create a canUseTool callback that restricts Write/Edit to allowed directories.
  *
  * Matches the Agent SDK's CanUseTool signature:
  *   (toolName, input, options) => Promise<PermissionResult>
+ *
+ * DEPRECATED for the Claude SDK runner: claude-agent-sdk 0.3.x does not invoke
+ * canUseTool under permissionMode 'bypassPermissions'. Use createPreToolUseHook
+ * with permissionMode 'dontAsk' instead. Retained for API compatibility.
  */
 export function createToolPolicy(
   allowedWriteDirs: string[],


### PR DESCRIPTION
Found by runtime-testing the dependency bumps from #123.

## 1. Security regression — write restriction silently disabled
The Claude SDK runner set `permissionMode: 'bypassPermissions'` **and** `canUseTool`. In `@anthropic-ai/claude-agent-sdk` 0.3.x, `bypassPermissions` pre-approves every tool call *before* `canUseTool` is consulted (emits `CLAUDE_SDK_CAN_USE_TOOL_SHADOWED`), so the Write/Edit → allowed-directory restriction was **not enforced**.

**Fix:** switch to `permissionMode: 'dontAsk'` + a `PreToolUse` hook (`createPreToolUseHook`). The hook is consulted per tool call and never prompts, so it enforces the restriction while staying headless. `createToolPolicy` (canUseTool) kept for API compatibility, marked deprecated.

## 2. ADK runner script path (pre-existing, from #108)
`resolveScriptPath()` used a single relative depth to `python/adk_runner.py`, correct for `src/` (tsx) but wrong for the compiled `dist/src/` layout — so `--runner google-adk` failed with `No such file` in any built/published run. Now probes both candidate depths; also added `python` to `package.json` `files` so the script ships on publish.

## Test gap closed
`canUseTool`/hook enforcement had **no** unit test — that's how the regression passed CI. Added `createPreToolUseHook` tests: non-write allow, write inside/outside allowed dirs, Edit deny, prefix-attack, empty-config, non-PreToolUse passthrough.

## Verification
- `claude-sdk` run: no shadow warning, PASS, discovery 100%
- `google-adk` run (gemini-2.5-flash): script resolves, PASS, discovery 100%
- typecheck ✓ · build ✓ · **425 tests** (+7) ✓ · bundle in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)