### PR TITLE
docs: gemini runner will be replaced by Antigravity, not verified

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CLI for evaluating [Agent Skills](https://agentskills.io/home) - a format for ex
 - `src/runner/claude-sdk-runner.ts` - Claude Agent SDK runner
 - `src/runner/claude-code-runner.ts` - Claude Code CLI runner (stream-json subprocess)
 - `src/runner/codex-runner.ts` - Codex CLI runner (`codex exec --json`, e2e-verified)
-- `src/runner/gemini-runner.ts` - EXPERIMENTAL CLI runner (docs-derived, synthetic-fixture tested)
+- `src/runner/gemini-runner.ts` - EXPERIMENTAL CLI runner (docs-derived, synthetic-fixture tested; will be REPLACED by an Antigravity CLI runner — Gemini CLI is deprecated for consumer tiers, see issue #126)
 - `src/runner/opencode-runner.ts` - OpenCode CLI runner (e2e-verified against opencode 1.17.13; env-based per-trial isolation)
 - `src/harness/subprocess.ts` - Shared CLI spawn/JSONL/process-tree-kill plumbing
 - `src/runner/base-runner.ts` - Shared runner base class (timeout wrapper, skillsMountPath)
@@ -78,7 +78,7 @@ Five runners selected via `--runner` flag:
 - `claude-sdk` (default) — uses Claude Agent SDK, model aliases like `sonnet`, `haiku`, `opus`
 - `claude-code` — drives the real Claude Code CLI (`claude -p --output-format stream-json --setting-sources project`) as a subprocess per task; requires `claude` on PATH (`npm install -g @anthropic-ai/claude-code`); timeouts kill the whole CLI process tree (`src/harness/subprocess.ts`)
 - `codex` — drives the Codex CLI (`codex exec --json --skip-git-repo-check --ignore-user-config --ephemeral`); skills mount at `.agents/skills/`; invocation detected from SKILL.md shell reads; token usage from `turn.completed`; requires `codex` on PATH (`npm install -g @openai/codex`) and Codex auth. `--model` is only forwarded when set to something other than the framework default (codex picks its own default model otherwise)
-- `gemini` (EXPERIMENTAL) — `gemini -p --output-format stream-json --approval-mode yolo`; skills mount at `.gemini/skills/`; built from official docs, not yet verified against a live CLI
+- `gemini` (EXPERIMENTAL) — `gemini -p --output-format stream-json --approval-mode yolo`; skills mount at `.gemini/skills/`; built from official docs, never live-verified and slated for REPLACEMENT by an `antigravity` runner (Gemini CLI deprecated for consumer tiers June 2026; Antigravity CLI keeps Agent Skills — issue #126)
 - `opencode` — `opencode run --format json --auto`; skills mount at `.opencode/skills/`; e2e-verified against opencode 1.17.13 (real captured transcript). `--model` takes `provider/model` form (e.g. `anthropic/claude-haiku-4-5`). No ignore-user-config flag exists, so the runner isolates per trial via env vars (`XDG_*` + `OPENCODE_TEST_HOME` in a per-trial temp dir, `OPENCODE_DISABLE_EXTERNAL_SKILLS=1`, `OPENCODE_PURE=1`, OAuth auth forwarded via `OPENCODE_AUTH_CONTENT` — see the runner JSDoc); the built-in `customize-opencode` skill is excluded from invocation detection (runner + deterministic scorer)
 
 Security: the CLI runners (`claude-code`, `codex`, `gemini`, `opencode`) run the agent fully auto-approved on the host with NO write restrictions (a one-time warning is printed); only `claude-sdk` enforces `allowed_write_dirs` via a PreToolUse hook, and `--sandbox docker` isolates verifiers, never the agent.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A task must define at least one of `checks:`, a `verifier/` script, or `assertio
 | `claude-sdk` (default) | stable | Claude Agent SDK in-process | `.claude/skills` | `ANTHROPIC_API_KEY` |
 | `claude-code` | stable | `claude -p --output-format stream-json --setting-sources project` | `.claude/skills` | `npm i -g @anthropic-ai/claude-code` |
 | `codex` | stable (e2e-verified) | `codex exec --json --skip-git-repo-check --ignore-user-config --ephemeral` | `.agents/skills` | `npm i -g @openai/codex` + `codex login` |
-| `gemini` | **experimental** | `gemini -p --output-format stream-json --approval-mode yolo` | `.gemini/skills` | `npm i -g @google/gemini-cli` |
+| `gemini` | **experimental, to be replaced** | `gemini -p --output-format stream-json --approval-mode yolo` | `.gemini/skills` | `npm i -g @google/gemini-cli` |
 | `opencode` | stable (e2e-verified) | `opencode run --format json --auto` + isolation env | `.opencode/skills` | `npm i -g opencode-ai` |
 
 Notes:
@@ -103,7 +103,7 @@ Notes:
 - `--model` semantics differ per runner: `claude-sdk`/`claude-code` take Claude aliases (`sonnet`, `haiku`, `opus`); `codex`/`gemini`/`opencode` only forward `--model` when you set one explicitly (otherwise each CLI uses its own default — Claude aliases are never forwarded to non-Claude CLIs). OpenCode expects `provider/model` form.
 - Skill invocation detection: Claude runners see the native `Skill` tool; `codex` detects shell reads of `SKILL.md` (its native discovery mechanism, verified in captured transcripts); `gemini`/`opencode` look for their native `activate_skill`/`skill` tools plus SKILL.md reads as fallback.
 - Isolation: `claude-code` passes `--setting-sources project`, `codex` passes `--ignore-user-config --ephemeral`, and `opencode` sets per-trial isolation env vars (opencode has no ignore-user-config flag; see the JSDoc in `src/runner/opencode-runner.ts` for the exact set) so your global config and skills don't leak into trials. Auth still works via provider env keys (`ANTHROPIC_API_KEY` etc.) and, for `opencode auth login` OAuth users, by forwarding the real `auth.json` content into the trial. All CLI runners spawn with `PWD` pinned to the trial workspace (some CLI runtimes trust `env.PWD` over the real cwd). The `gemini` runner has **no verified isolation story yet** — global gemini config and skills may leak into trials; see the JSDoc in `src/runner/gemini-runner.ts`.
-- `gemini` was built from official docs but has not been verified against a live CLI — it warns on first use, and a captured transcript is wanted (see `src/__tests__/fixtures/transcripts/README.md`). `opencode` was verified live against opencode 1.17.13 (real captured transcript, isolation probe, error-shape capture).
+- `gemini` was built from official docs and will NOT be live-verified: Google deprecated Gemini CLI for consumer tiers (June 2026) in favor of Antigravity CLI, so the plan is an `antigravity` runner replacing it (tracked in [#126](https://github.com/olaservo/skilljack-evals/issues/126)); the gemini runner warns on first use and remains only for enterprise-licensed legacy users until then. `opencode` was verified live against opencode 1.17.13 (real captured transcript, isolation probe, error-shape capture).
 
 ### Security model
 

--- a/src/__tests__/fixtures/transcripts/README.md
+++ b/src/__tests__/fixtures/transcripts/README.md
@@ -42,6 +42,6 @@ Verified contract:
 
 ## gemini — SYNTHETIC fixture only
 
-The gemini CLI is not installed on the dev machine, so `gemini/synthetic-*.jsonl` is HAND-WRITTEN from the officially documented output shapes (July 2026 docs), NOT a captured transcript. The runner built on it is marked experimental; replace with a real capture when the CLI is available.
+The gemini CLI is not installed on the dev machine, so `gemini/synthetic-*.jsonl` is HAND-WRITTEN from the officially documented output shapes (July 2026 docs), NOT a captured transcript. The runner built on it is marked experimental and will NOT be live-verified: Google deprecated Gemini CLI for consumer tiers (June 2026) in favor of Antigravity CLI, so the planned path is a new `antigravity` runner spiked with this same capture procedure (issue #126) — the opencode spike above is the template (reuse the `CliRunner` scratch-dir/`buildEnv` contract for env-based isolation, check for bundled builtin skills, and remember `PWD` is already pinned at the base for all CLI runners).
 
 - gemini: `gemini -p "<prompt>" --output-format stream-json --approval-mode yolo` (docs-verified; the plan's `--output-format json --yolo` guess was revised — single-object json mode omits tool arguments, which SKILL.md-read detection needs). Skills discovered from `.gemini/skills/` (alias `.agents/skills/`); native `activate_skill` tool is the primary invocation surface.

--- a/src/runner/gemini-runner.ts
+++ b/src/runner/gemini-runner.ts
@@ -1,10 +1,14 @@
 /**
- * Gemini CLI Runner — EXPERIMENTAL.
+ * Gemini CLI Runner — EXPERIMENTAL, slated for replacement.
  *
  * Built from the official Gemini CLI docs (headless mode, Agent Skills,
- * stream-json output), NOT yet verified against a live CLI on this machine —
- * captured transcripts wanted. Unit tests replay a hand-written SYNTHETIC
- * fixture (src/__tests__/fixtures/transcripts/gemini/synthetic-*.jsonl).
+ * stream-json output), NOT verified against a live CLI — and it never will
+ * be: Google deprecated Gemini CLI for consumer tiers (June 2026) in favor
+ * of Antigravity CLI, which keeps Agent Skills. The plan (issue #126) is an
+ * `antigravity` runner spiked per fixtures/transcripts/README.md; this
+ * runner remains only for enterprise-licensed legacy users until then. Unit
+ * tests replay a hand-written SYNTHETIC fixture
+ * (src/__tests__/fixtures/transcripts/gemini/synthetic-*.jsonl).
  *
  * Documented facts this implementation relies on (geminicli.com/docs, July 2026):
  * - Headless: `gemini -p "<prompt>" --output-format stream-json` emits JSONL


### PR DESCRIPTION
Aligns the repo docs with the re-scoped plan in #126: the experimental `gemini` runner will NOT get a live-transcript verification pass — Google deprecated Gemini CLI for consumer tiers (June 2026) in favor of Antigravity CLI (which retains Agent Skills), so the plan is a new `antigravity` runner spiked per the transcripts-README procedure, with the gemini runner kept only for enterprise-licensed legacy users until it's replaced.

Docs-only (plus the gemini runner's JSDoc header): README runner table/notes, CLAUDE.md runner entries, `src/runner/gemini-runner.ts` header, and the transcripts README gemini section (which now points the future Antigravity spike at the opencode template: CliRunner scratch-dir/buildEnv contract, builtin-skill checks, base-level PWD pin).

Tests green (620), bundle refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)